### PR TITLE
feat: add fixture, horses, shop and refuge pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,8 @@
         "ethers": "^5.5.1",
         "lucide-angular": "^0.483.0",
         "ngrx-store-localstorage": "^19.0.0",
+        "primeicons": "^7.0.0",
+        "primeng": "^19.1.4",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -6319,6 +6321,27 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@primeuix/styled": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-0.3.2.tgz",
+      "integrity": "sha512-ColZes0+/WKqH4ob2x8DyNYf1NENpe5ZguOvx5yCLxaP8EIMVhLjWLO/3umJiDnQU4XXMLkn2mMHHw+fhTX/mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@primeuix/utils": "^0.3.2"
+      },
+      "engines": {
+        "node": ">=12.11.0"
+      }
+    },
+    "node_modules/@primeuix/utils": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.3.2.tgz",
+      "integrity": "sha512-B+nphqTQeq+i6JuICLdVWnDMjONome2sNz0xI65qIOyeB4EF12CoKRiCsxuZ5uKAkHi/0d1LqlQ9mIWRSdkavw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.11.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -12637,6 +12660,33 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/primeicons": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/primeicons/-/primeicons-7.0.0.tgz",
+      "integrity": "sha512-jK3Et9UzwzTsd6tzl2RmwrVY/b8raJ3QZLzoDACj+oTJ0oX7L9Hy+XnVwgo4QVKlKpnP/Ur13SXV/pVh4LzaDw==",
+      "license": "MIT"
+    },
+    "node_modules/primeng": {
+      "version": "19.1.4",
+      "resolved": "https://registry.npmjs.org/primeng/-/primeng-19.1.4.tgz",
+      "integrity": "sha512-l5l8SHTxopxxyyXZx1BvbQ11P7ndLv2Qp8H5k2/+OCi65jTZn4xmtrBDGDs7k2K5UMHSqAnGjBgtpbckyqQETg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@primeuix/styled": "^0.3.2",
+        "@primeuix/utils": "^0.3.2",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": "^19.0.0",
+        "@angular/cdk": "^19.0.0",
+        "@angular/common": "^19.0.0",
+        "@angular/core": "^19.0.0",
+        "@angular/forms": "^19.0.0",
+        "@angular/platform-browser": "^19.0.0",
+        "@angular/router": "^19.0.0",
+        "rxjs": "^6.0.0 || ^7.8.1"
+      }
     },
     "node_modules/proc-log": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "ethers": "^5.5.1",
     "lucide-angular": "^0.483.0",
     "ngrx-store-localstorage": "^19.0.0",
+    "primeicons": "^7.0.0",
+    "primeng": "^19.1.4",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/public/assets/locals/en.json
+++ b/public/assets/locals/en.json
@@ -11,6 +11,25 @@
                 "EN": "English",
                 "ES": "Spanish"
             }
+        },
+        "FIXTURE": {
+            "NAME": "Fixture"
+        },
+        "HORSES": {
+            "NAME": "Horses",
+            "FORGE": { "NAME": "Foal Forge" },
+            "TRADING": { "NAME": "Trading Ground" }
+        },
+        "SHOP": {
+            "NAME": "Tack Shop",
+            "SHOES": { "NAME": "Horseshoes" },
+            "HORSE": { "NAME": "Horse Closet" },
+            "JOCKEY": { "NAME": "Jockey Outfit" }
+        },
+        "REFUGE": {
+            "NAME": "Rider's Refuge",
+            "PADDOCK": { "NAME": "The Paddock" },
+            "INVENTORY": { "NAME": "Inventory" }
         }
     },
     "AUTH": {

--- a/public/assets/locals/es.json
+++ b/public/assets/locals/es.json
@@ -11,6 +11,25 @@
                 "EN": "Inglés",
                 "ES": "Español"
             }
+        },
+        "FIXTURE": {
+            "NAME": "Fixture"
+        },
+        "HORSES": {
+            "NAME": "Caballos",
+            "FORGE": { "NAME": "Potros" },
+            "TRADING": { "NAME": "Compra Venta" }
+        },
+        "SHOP": {
+            "NAME": "Tienda",
+            "SHOES": { "NAME": "Herraduras" },
+            "HORSE": { "NAME": "Estilo Equino" },
+            "JOCKEY": { "NAME": "Jinetes" }
+        },
+        "REFUGE": {
+            "NAME": "Refugio",
+            "PADDOCK": { "NAME": "Establo" },
+            "INVENTORY": { "NAME": "Inventario" }
         }
     },
     "AUTH": {

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,8 +1,14 @@
 import { Routes } from '@angular/router';
 import { HomeComponent } from '@app/pages/home/home.component';
+import { FixtureComponent } from '@app/pages/fixture/fixture.component';
+import { HorsesComponent } from '@app/pages/horses/horses.component';
+import { ShopComponent } from '@app/pages/shop/shop.component';
+import { RefugeComponent } from '@app/pages/refuge/refuge.component';
 
 export const routes: Routes = [
-    // Navigate to 'home' component by default (empty path)
     { path: '', component: HomeComponent },
-
+    { path: 'fixture', component: FixtureComponent },
+    { path: 'horses', component: HorsesComponent },
+    { path: 'shop', component: ShopComponent },
+    { path: 'refuge', component: RefugeComponent },
 ];

--- a/src/app/components/login/login.component.html
+++ b/src/app/components/login/login.component.html
@@ -15,9 +15,10 @@
 
             <!-- Dropdown Body -->
             <div dropdown-body class="c-login__menu-body">
-                <!--a class="c-login__menu-option" routerLink="/wallet">{{'PAGES.WALLET.NAME' | translate}}</a-->
-                <!--a class="c-login__menu-option" routerLink="/accounts">{{'PAGES.ACCOUNTS.NAME' | translate}}</a-->
-                <!--a class="c-login__menu-option" routerLink="/preferences">{{'PAGES.PREFERENCES.NAME' | translate}}</a-->
+                <a class="c-login__menu-option" routerLink="/fixture">{{ 'PAGES.FIXTURE.NAME' | translate }}</a>
+                <a class="c-login__menu-option" routerLink="/horses">{{ 'PAGES.HORSES.NAME' | translate }}</a>
+                <a class="c-login__menu-option" routerLink="/shop">{{ 'PAGES.SHOP.NAME' | translate }}</a>
+                <a class="c-login__menu-option" routerLink="/refuge">{{ 'PAGES.REFUGE.NAME' | translate }}</a>
                 <hr class="c-login__menu-separator">
                 <a class="c-login__menu-option" (click)="logout()">{{'AUTH.LOGOUT' | translate}}</a>
             </div>

--- a/src/app/components/nav-bar/nav-bar.component.html
+++ b/src/app/components/nav-bar/nav-bar.component.html
@@ -3,10 +3,12 @@
 <ng-container *ngIf="!isMobileView; else mobileNav">
     <nav class="c-navbar">
         <div class="c-navbar__row">
-            <img  class="c-navbar__logo"src="assets/game-img/gold-horse.png" routerLink="/" width="50px">
+            <img class="c-navbar__logo" src="assets/game-img/gold-horse.png" routerLink="/" width="50px">
 
-            <!--a class="c-navbar__button" routerLink="/accounts" routerLinkActive="active-link">{{ 'PAGES.ACCOUNTS.NAME' | translate }}</a-->
-            <!--a class="c-navbar__button" *ngIf="isLogged" routerLink="/wallet" routerLinkActive="active-link">{{ 'PAGES.WALLET.NAME' | translate }}</a-->
+            <a class="c-navbar__button" routerLink="/fixture" routerLinkActive="active-link">{{ 'PAGES.FIXTURE.NAME' | translate }}</a>
+            <a class="c-navbar__button" routerLink="/horses" routerLinkActive="active-link">{{ 'PAGES.HORSES.NAME' | translate }}</a>
+            <a class="c-navbar__button" routerLink="/shop" routerLinkActive="active-link">{{ 'PAGES.SHOP.NAME' | translate }}</a>
+            <a class="c-navbar__button" routerLink="/refuge" routerLinkActive="active-link">{{ 'PAGES.REFUGE.NAME' | translate }}</a>
         </div>
 
         <div class="c-navbar__row">

--- a/src/app/pages/fixture/fixture.component.scss
+++ b/src/app/pages/fixture/fixture.component.scss
@@ -1,0 +1,3 @@
+.p-fixture {
+    padding: 1rem;
+}

--- a/src/app/pages/fixture/fixture.component.ts
+++ b/src/app/pages/fixture/fixture.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { SharedModule } from '@app/shared/shared.module';
+
+@Component({
+    standalone: true,
+    selector: 'app-fixture',
+    imports: [SharedModule],
+    template: `
+        <div class="p-fixture">
+            <h1>{{ 'PAGES.FIXTURE.NAME' | translate }}</h1>
+        </div>
+    `,
+    styleUrls: ['./fixture.component.scss']
+})
+export class FixtureComponent {}

--- a/src/app/pages/horses/horses.component.scss
+++ b/src/app/pages/horses/horses.component.scss
@@ -1,0 +1,3 @@
+.p-horses {
+    padding: 1rem;
+}

--- a/src/app/pages/horses/horses.component.ts
+++ b/src/app/pages/horses/horses.component.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+import { SharedModule } from '@app/shared/shared.module';
+import { TabViewModule } from 'primeng/tabview';
+
+@Component({
+    standalone: true,
+    selector: 'app-horses',
+    imports: [SharedModule, TabViewModule],
+    template: `
+        <div class="p-horses">
+            <p-tabView>
+                <p-tabPanel header="{{ 'PAGES.HORSES.FORGE.NAME' | translate }}">
+                </p-tabPanel>
+                <p-tabPanel header="{{ 'PAGES.HORSES.TRADING.NAME' | translate }}">
+                </p-tabPanel>
+            </p-tabView>
+        </div>
+    `,
+    styleUrls: ['./horses.component.scss']
+})
+export class HorsesComponent {}

--- a/src/app/pages/refuge/refuge.component.scss
+++ b/src/app/pages/refuge/refuge.component.scss
@@ -1,0 +1,3 @@
+.p-refuge {
+    padding: 1rem;
+}

--- a/src/app/pages/refuge/refuge.component.ts
+++ b/src/app/pages/refuge/refuge.component.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+import { SharedModule } from '@app/shared/shared.module';
+import { TabViewModule } from 'primeng/tabview';
+
+@Component({
+    standalone: true,
+    selector: 'app-refuge',
+    imports: [SharedModule, TabViewModule],
+    template: `
+        <div class="p-refuge">
+            <p-tabView>
+                <p-tabPanel header="{{ 'PAGES.REFUGE.PADDOCK.NAME' | translate }}">
+                </p-tabPanel>
+                <p-tabPanel header="{{ 'PAGES.REFUGE.INVENTORY.NAME' | translate }}">
+                </p-tabPanel>
+            </p-tabView>
+        </div>
+    `,
+    styleUrls: ['./refuge.component.scss']
+})
+export class RefugeComponent {}

--- a/src/app/pages/shop/shop.component.scss
+++ b/src/app/pages/shop/shop.component.scss
@@ -1,0 +1,3 @@
+.p-shop {
+    padding: 1rem;
+}

--- a/src/app/pages/shop/shop.component.ts
+++ b/src/app/pages/shop/shop.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { SharedModule } from '@app/shared/shared.module';
+import { TabViewModule } from 'primeng/tabview';
+
+@Component({
+    standalone: true,
+    selector: 'app-shop',
+    imports: [SharedModule, TabViewModule],
+    template: `
+        <div class="p-shop">
+            <p-tabView>
+                <p-tabPanel header="{{ 'PAGES.SHOP.SHOES.NAME' | translate }}">
+                </p-tabPanel>
+                <p-tabPanel header="{{ 'PAGES.SHOP.HORSE.NAME' | translate }}">
+                </p-tabPanel>
+                <p-tabPanel header="{{ 'PAGES.SHOP.JOCKEY.NAME' | translate }}">
+                </p-tabPanel>
+            </p-tabView>
+        </div>
+    `,
+    styleUrls: ['./shop.component.scss']
+})
+export class ShopComponent {}


### PR DESCRIPTION
## Summary
- add Fixture, Horses, Shop and Refuge pages with PrimeNG tab views
- expose new sections in the navigation bar and login dropdown
- include English and Spanish translations for new pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve @vapaee/w3o-core and related modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f87147dc8320944c320ff5829d90