### PR TITLE
feat: add tab navigation for shop and refuge

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -13,7 +13,23 @@ export const routes: Routes = [
             { path: 'trading', loadComponent: () => import('@app/pages/trading/trading.component').then(m => m.TradingPage) }
         ]
     },
-
-    { path: 'shop', loadComponent: () => import('@app/pages/shop/shop.component').then(m => m.ShopPage) },
-    { path: 'refuge', loadComponent: () => import('@app/pages/refuge/refuge.component').then(m => m.RefugePage) }
+    {
+        path: 'shop',
+        loadComponent: () => import('@app/pages/shop/shop.component').then(m => m.ShopPage),
+        children: [
+            { path: '', pathMatch: 'full', redirectTo: 'horseshoes' },
+            { path: 'horseshoes', loadComponent: () => import('@app/pages/horseshoes/horseshoes.component').then(m => m.HorseshoesPage) },
+            { path: 'accessories', loadComponent: () => import('@app/pages/accessories/accessories.component').then(m => m.AccessoriesPage) },
+            { path: 'jockeys', loadComponent: () => import('@app/pages/jockeys/jockeys.component').then(m => m.JockeysPage) }
+        ]
+    },
+    {
+        path: 'refuge',
+        loadComponent: () => import('@app/pages/refuge/refuge.component').then(m => m.RefugePage),
+        children: [
+            { path: '', pathMatch: 'full', redirectTo: 'paddock' },
+            { path: 'paddock', loadComponent: () => import('@app/pages/paddock/paddock.component').then(m => m.PaddockPage) },
+            { path: 'inventory', loadComponent: () => import('@app/pages/inventory/inventory.component').then(m => m.InventoryPage) }
+        ]
+    }
 ];

--- a/src/app/components/side-menu-mobile/side-menu-mobile.component.html
+++ b/src/app/components/side-menu-mobile/side-menu-mobile.component.html
@@ -4,34 +4,21 @@
 
     <hr class="c-side-menu__separator">
 
-    <a class="c-side-menu__option" routerLink="/" routerLinkActive="active-link" [routerLinkActiveOptions]="{ exact: true }">
+    <a class="c-side-menu__option" routerLink="/fixture" routerLinkActive="active-link">
+        <lucide-icon [img]="CalendarIcon"></lucide-icon>
+        <p>{{ 'PAGES.FIXTURE.NAME' | translate }}</p>
+    </a>
+    <a class="c-side-menu__option" routerLink="/horses" routerLinkActive="active-link">
+        <lucide-icon [img]="HorseIcon"></lucide-icon>
+        <p>{{ 'PAGES.HORSES.NAME' | translate }}</p>
+    </a>
+    <a class="c-side-menu__option" routerLink="/shop" routerLinkActive="active-link">
+        <lucide-icon [img]="ShoppingBagIcon"></lucide-icon>
+        <p>{{ 'PAGES.SHOP.NAME' | translate }}</p>
+    </a>
+    <a class="c-side-menu__option" routerLink="/refuge" routerLinkActive="active-link">
         <lucide-icon [img]="HomeIcon"></lucide-icon>
-        <p>{{'PAGES.HOME.NAME' | translate}}</p>
-    </a>
-    <a class="c-side-menu__option" routerLink="/accounts" routerLinkActive="active-link">
-        <lucide-icon [img]="UsersIcon"></lucide-icon>
-        <p>{{'PAGES.ACCOUNTS.NAME' | translate}}</p>
-    </a>
-
-    <hr class="c-side-menu__separator">
-
-    <a class="c-side-menu__option" routerLink="/wallet" routerLinkActive="active-link">
-        <lucide-icon [img]="WalletIcon"></lucide-icon>
-        <p>{{'PAGES.WALLET.NAME' | translate}}</p>
-    </a>
-    <a *ngIf="isAntelope" class="c-side-menu__option" routerLink="/resources" routerLinkActive="active-link">
-        <lucide-icon [img]="WalletIcon"></lucide-icon>
-        <p>{{'PAGES.RESOURCES.NAME' | translate}}</p>
-    </a>
-
-    <a class="c-side-menu__option" routerLink="/preferences" routerLinkActive="active-link">
-        <lucide-icon [img]="SettingsIcon"></lucide-icon>
-        <p>{{'PAGES.PREFERENCES.NAME' | translate}}</p>
-    </a>
-
-    <a class="c-side-menu__option" routerLink="/" routerLinkActive="active-link" *ngIf="isLogged" (click)="logout()">
-        <lucide-icon [img]="LogoutIcon"></lucide-icon>
-        <p>{{'TYPES.BUTTON.LOGOUT' | translate}}</p>
+        <p>{{ 'PAGES.REFUGE.NAME' | translate }}</p>
     </a>
 
 </app-side-container>

--- a/src/app/components/side-menu-mobile/side-menu-mobile.component.ts
+++ b/src/app/components/side-menu-mobile/side-menu-mobile.component.ts
@@ -1,17 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import { SideContainerComponent } from '@app/components/base-components/side-container/side-container.component';
-import {
-    LucideAngularModule,
-    Home,
-    Settings,
-    Wallet,
-    LogOut,
-    Users
-} from 'lucide-angular';
+import { LucideAngularModule, Calendar, Horse, ShoppingBag, Home } from 'lucide-angular';
 import { RouterModule } from '@angular/router';
-import { SessionService } from '@app/services/session-kit.service';
 import { SharedModule } from '@app/shared/shared.module';
-import { Web3OctopusService } from '@app/services/web3-octopus.service';
 
 @Component({
     selector: 'app-side-menu-mobile',
@@ -22,39 +13,12 @@ import { Web3OctopusService } from '@app/services/web3-octopus.service';
         SharedModule
     ],
     templateUrl: './side-menu-mobile.component.html',
-    styleUrl: './side-menu-mobile.component.scss'
+    styleUrl: './side-menu-mobile.component.scss',
+    encapsulation: ViewEncapsulation.None
 })
 export class SideMenuMobileComponent {
+    readonly CalendarIcon = Calendar;
+    readonly HorseIcon = Horse;
+    readonly ShoppingBagIcon = ShoppingBag;
     readonly HomeIcon = Home;
-    readonly SettingsIcon = Settings;
-    readonly WalletIcon = Wallet;
-    readonly LogoutIcon = LogOut;
-    readonly UsersIcon = Users
-
-    // public isLogged: boolean = false;
-    // constructor(
-    //     public sessionService: SessionService
-    // ) {
-    //     this.sessionService.session$.subscribe((session) => {
-    //         this.isLogged = !!session;
-    //     });
-    // }
-
-    constructor(
-        public sessionService: SessionService,
-        private w3o: Web3OctopusService
-    ) {}
-
-    get isAntelope(): boolean {
-        return this.w3o.octopus.networks.current.type === 'antelope';
-    }
-
-    get isLogged(): boolean {
-        return !!this.sessionService.current;
-    }
-
-    async logout() {
-        await this.sessionService.logout();
-    }
-
 }

--- a/src/app/pages/accessories/accessories.component.scss
+++ b/src/app/pages/accessories/accessories.component.scss
@@ -1,0 +1,7 @@
+@use 'mixin' as *;
+
+.p-accessories {
+    &__title {
+        @include tabs-content-title;
+    }
+}

--- a/src/app/pages/accessories/accessories.component.ts
+++ b/src/app/pages/accessories/accessories.component.ts
@@ -1,0 +1,16 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+import { SharedModule } from '@app/shared/shared.module';
+
+@Component({
+    standalone: true,
+    selector: 'app-accessories',
+    imports: [SharedModule],
+    template: `
+        <section class="p-accessories">
+            <span class="p-accessories__title">{{ 'PAGES.SHOP.HORSE.NAME' | translate }}</span>
+        </section>
+    `,
+    styleUrls: ['./accessories.component.scss'],
+    encapsulation: ViewEncapsulation.None
+})
+export class AccessoriesPage {}

--- a/src/app/pages/horseshoes/horseshoes.component.scss
+++ b/src/app/pages/horseshoes/horseshoes.component.scss
@@ -1,0 +1,7 @@
+@use 'mixin' as *;
+
+.p-horseshoes {
+    &__title {
+        @include tabs-content-title;
+    }
+}

--- a/src/app/pages/horseshoes/horseshoes.component.ts
+++ b/src/app/pages/horseshoes/horseshoes.component.ts
@@ -1,0 +1,16 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+import { SharedModule } from '@app/shared/shared.module';
+
+@Component({
+    standalone: true,
+    selector: 'app-horseshoes',
+    imports: [SharedModule],
+    template: `
+        <section class="p-horseshoes">
+            <span class="p-horseshoes__title">{{ 'PAGES.SHOP.SHOES.NAME' | translate }}</span>
+        </section>
+    `,
+    styleUrls: ['./horseshoes.component.scss'],
+    encapsulation: ViewEncapsulation.None
+})
+export class HorseshoesPage {}

--- a/src/app/pages/inventory/inventory.component.scss
+++ b/src/app/pages/inventory/inventory.component.scss
@@ -1,0 +1,7 @@
+@use 'mixin' as *;
+
+.p-inventory {
+    &__title {
+        @include tabs-content-title;
+    }
+}

--- a/src/app/pages/inventory/inventory.component.ts
+++ b/src/app/pages/inventory/inventory.component.ts
@@ -1,0 +1,16 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+import { SharedModule } from '@app/shared/shared.module';
+
+@Component({
+    standalone: true,
+    selector: 'app-inventory',
+    imports: [SharedModule],
+    template: `
+        <section class="p-inventory">
+            <span class="p-inventory__title">{{ 'PAGES.REFUGE.INVENTORY.NAME' | translate }}</span>
+        </section>
+    `,
+    styleUrls: ['./inventory.component.scss'],
+    encapsulation: ViewEncapsulation.None
+})
+export class InventoryPage {}

--- a/src/app/pages/jockeys/jockeys.component.scss
+++ b/src/app/pages/jockeys/jockeys.component.scss
@@ -1,0 +1,7 @@
+@use 'mixin' as *;
+
+.p-jockeys {
+    &__title {
+        @include tabs-content-title;
+    }
+}

--- a/src/app/pages/jockeys/jockeys.component.ts
+++ b/src/app/pages/jockeys/jockeys.component.ts
@@ -1,0 +1,16 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+import { SharedModule } from '@app/shared/shared.module';
+
+@Component({
+    standalone: true,
+    selector: 'app-jockeys',
+    imports: [SharedModule],
+    template: `
+        <section class="p-jockeys">
+            <span class="p-jockeys__title">{{ 'PAGES.SHOP.JOCKEY.NAME' | translate }}</span>
+        </section>
+    `,
+    styleUrls: ['./jockeys.component.scss'],
+    encapsulation: ViewEncapsulation.None
+})
+export class JockeysPage {}

--- a/src/app/pages/paddock/paddock.component.scss
+++ b/src/app/pages/paddock/paddock.component.scss
@@ -1,0 +1,7 @@
+@use 'mixin' as *;
+
+.p-paddock {
+    &__title {
+        @include tabs-content-title;
+    }
+}

--- a/src/app/pages/paddock/paddock.component.ts
+++ b/src/app/pages/paddock/paddock.component.ts
@@ -1,0 +1,16 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+import { SharedModule } from '@app/shared/shared.module';
+
+@Component({
+    standalone: true,
+    selector: 'app-paddock',
+    imports: [SharedModule],
+    template: `
+        <section class="p-paddock">
+            <span class="p-paddock__title">{{ 'PAGES.REFUGE.PADDOCK.NAME' | translate }}</span>
+        </section>
+    `,
+    styleUrls: ['./paddock.component.scss'],
+    encapsulation: ViewEncapsulation.None
+})
+export class PaddockPage {}

--- a/src/app/pages/refuge/refuge.component.scss
+++ b/src/app/pages/refuge/refuge.component.scss
@@ -1,3 +1,15 @@
+@use 'mixin' as *;
+
+app-refuge {
+    @include page;
+}
+
 .p-refuge {
-    padding: 1rem;
+    &__tabs {
+        @include tabs;
+    }
+
+    &__tabs-content {
+        @include tabs-content;
+    }
 }

--- a/src/app/pages/refuge/refuge.component.ts
+++ b/src/app/pages/refuge/refuge.component.ts
@@ -1,21 +1,74 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
 import { SharedModule } from '@app/shared/shared.module';
-import { TabViewModule } from 'primeng/tabview';
+import { TabMenu } from 'primeng/tabmenu';
+import { MenuItem } from 'primeng/api';
+import { filter, Subscription } from 'rxjs';
 
 @Component({
     standalone: true,
     selector: 'app-refuge',
-    imports: [SharedModule, TabViewModule],
+    imports: [SharedModule, TabMenu, RouterOutlet],
     template: `
-        <div class="p-refuge">
-            <p-tabView>
-                <p-tabPanel header="{{ 'PAGES.REFUGE.PADDOCK.NAME' | translate }}">
-                </p-tabPanel>
-                <p-tabPanel header="{{ 'PAGES.REFUGE.INVENTORY.NAME' | translate }}">
-                </p-tabPanel>
-            </p-tabView>
+        <p-tabmenu
+            class="p-refuge__tabs"
+            [model]="items"
+            [activeItem]="activeItem"
+            (activeItemChange)="onActiveItemChange($event)">
+        </p-tabmenu>
+
+        <div class="p-refuge__tabs-content">
+            <router-outlet></router-outlet>
         </div>
     `,
-    styleUrls: ['./refuge.component.scss']
+    styleUrls: ['./refuge.component.scss'],
+    encapsulation: ViewEncapsulation.None
 })
-export class RefugePage {}
+export class RefugePage implements OnInit, OnDestroy {
+    items: MenuItem[] = [];
+    activeItem?: MenuItem;
+    private sub?: Subscription;
+
+    constructor(
+        private translate: TranslateService,
+        private router: Router
+    ) {}
+
+    ngOnInit(): void {
+        this.buildItems();
+        this.sub = this.router.events
+            .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
+            .subscribe(() => this.syncActiveFromUrl());
+        this.syncActiveFromUrl();
+        this.translate.onLangChange.subscribe(() => {
+            this.buildItems();
+            this.syncActiveFromUrl();
+        });
+    }
+
+    ngOnDestroy(): void {
+        this.sub?.unsubscribe();
+    }
+
+    onActiveItemChange(item: MenuItem): void {
+        this.activeItem = item;
+    }
+
+    private buildItems(): void {
+        const paddockLabel = this.translate.instant('PAGES.REFUGE.PADDOCK.NAME');
+        const inventoryLabel = this.translate.instant('PAGES.REFUGE.INVENTORY.NAME');
+
+        this.items = [
+            { label: paddockLabel, icon: 'pi pi-home', routerLink: ['/refuge', 'paddock'] },
+            { label: inventoryLabel, icon: 'pi pi-briefcase', routerLink: ['/refuge', 'inventory'] }
+        ];
+    }
+
+    private syncActiveFromUrl(): void {
+        const segments = this.router.url.split('/');
+        const tab = segments[2] || 'paddock';
+        const index = tab === 'inventory' ? 1 : 0;
+        this.activeItem = this.items[index];
+    }
+}

--- a/src/app/pages/shop/shop.component.scss
+++ b/src/app/pages/shop/shop.component.scss
@@ -1,3 +1,15 @@
+@use 'mixin' as *;
+
+app-shop {
+    @include page;
+}
+
 .p-shop {
-    padding: 1rem;
+    &__tabs {
+        @include tabs;
+    }
+
+    &__tabs-content {
+        @include tabs-content;
+    }
 }

--- a/src/app/pages/shop/shop.component.ts
+++ b/src/app/pages/shop/shop.component.ts
@@ -1,23 +1,78 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
 import { SharedModule } from '@app/shared/shared.module';
-import { TabViewModule } from 'primeng/tabview';
+import { TabMenu } from 'primeng/tabmenu';
+import { MenuItem } from 'primeng/api';
+import { filter, Subscription } from 'rxjs';
 
 @Component({
     standalone: true,
     selector: 'app-shop',
-    imports: [SharedModule, TabViewModule],
+    imports: [SharedModule, TabMenu, RouterOutlet],
     template: `
-        <div class="p-shop">
-            <p-tabView>
-                <p-tabPanel header="{{ 'PAGES.SHOP.SHOES.NAME' | translate }}">
-                </p-tabPanel>
-                <p-tabPanel header="{{ 'PAGES.SHOP.HORSE.NAME' | translate }}">
-                </p-tabPanel>
-                <p-tabPanel header="{{ 'PAGES.SHOP.JOCKEY.NAME' | translate }}">
-                </p-tabPanel>
-            </p-tabView>
+        <p-tabmenu
+            class="p-shop__tabs"
+            [model]="items"
+            [activeItem]="activeItem"
+            (activeItemChange)="onActiveItemChange($event)">
+        </p-tabmenu>
+
+        <div class="p-shop__tabs-content">
+            <router-outlet></router-outlet>
         </div>
     `,
-    styleUrls: ['./shop.component.scss']
+    styleUrls: ['./shop.component.scss'],
+    encapsulation: ViewEncapsulation.None
 })
-export class ShopPage {}
+export class ShopPage implements OnInit, OnDestroy {
+    items: MenuItem[] = [];
+    activeItem?: MenuItem;
+    private sub?: Subscription;
+
+    constructor(
+        private translate: TranslateService,
+        private router: Router
+    ) {}
+
+    ngOnInit(): void {
+        this.buildItems();
+        this.sub = this.router.events
+            .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
+            .subscribe(() => this.syncActiveFromUrl());
+        this.syncActiveFromUrl();
+        this.translate.onLangChange.subscribe(() => {
+            this.buildItems();
+            this.syncActiveFromUrl();
+        });
+    }
+
+    ngOnDestroy(): void {
+        this.sub?.unsubscribe();
+    }
+
+    onActiveItemChange(item: MenuItem): void {
+        this.activeItem = item;
+    }
+
+    private buildItems(): void {
+        const shoesLabel = this.translate.instant('PAGES.SHOP.SHOES.NAME');
+        const accessoriesLabel = this.translate.instant('PAGES.SHOP.HORSE.NAME');
+        const jockeyLabel = this.translate.instant('PAGES.SHOP.JOCKEY.NAME');
+
+        this.items = [
+            { label: shoesLabel, icon: 'pi pi-briefcase', routerLink: ['/shop', 'horseshoes'] },
+            { label: accessoriesLabel, icon: 'pi pi-star', routerLink: ['/shop', 'accessories'] },
+            { label: jockeyLabel, icon: 'pi pi-user', routerLink: ['/shop', 'jockeys'] }
+        ];
+    }
+
+    private syncActiveFromUrl(): void {
+        const segments = this.router.url.split('/');
+        const tab = segments[2] || 'horseshoes';
+        let index = 0;
+        if (tab === 'accessories') index = 1;
+        else if (tab === 'jockeys') index = 2;
+        this.activeItem = this.items[index];
+    }
+}


### PR DESCRIPTION
## Summary
- add tabbed navigation with lazy routes for Shop and Refuge sections
- scaffold horseshoes, accessories, jockeys, paddock and inventory pages
- update mobile side menu to show main navigation items

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a49146fa388320b25c1c632d23e09f