### PR TITLE
Add under construction placeholder to pages

### DIFF
--- a/src/app/components/under-construction/under-construction.component.html
+++ b/src/app/components/under-construction/under-construction.component.html
@@ -1,0 +1,3 @@
+<div class="c-under-construction">
+    <img src="assets/images/under-construction.png" alt="Under construction" />
+</div>

--- a/src/app/components/under-construction/under-construction.component.scss
+++ b/src/app/components/under-construction/under-construction.component.scss
@@ -1,0 +1,12 @@
+.c-under-construction {
+    flex-grow: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+}
+
+.c-under-construction img {
+    max-width: 100%;
+    height: auto;
+}

--- a/src/app/components/under-construction/under-construction.component.ts
+++ b/src/app/components/under-construction/under-construction.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app-under-construction',
+    standalone: true,
+    templateUrl: './under-construction.component.html',
+    styleUrls: ['./under-construction.component.scss']
+})
+export class UnderConstructionComponent {}
+

--- a/src/app/pages/accessories/accessories.component.scss
+++ b/src/app/pages/accessories/accessories.component.scss
@@ -1,6 +1,11 @@
 @use 'mixin' as *;
 
 .p-accessories {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex-grow: 1;
+
     &__title {
         @include tabs-content-title;
     }

--- a/src/app/pages/accessories/accessories.component.ts
+++ b/src/app/pages/accessories/accessories.component.ts
@@ -1,13 +1,15 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 import { SharedModule } from '@app/shared/shared.module';
+import { UnderConstructionComponent } from '@app/components/under-construction/under-construction.component';
 
 @Component({
     standalone: true,
     selector: 'app-accessories',
-    imports: [SharedModule],
+    imports: [SharedModule, UnderConstructionComponent],
     template: `
         <section class="p-accessories">
             <span class="p-accessories__title">{{ 'PAGES.SHOP.ACCESSORIES.NAME' | translate }}</span>
+            <app-under-construction></app-under-construction>
         </section>
     `,
     styleUrls: ['./accessories.component.scss'],

--- a/src/app/pages/fixture/fixture.component.scss
+++ b/src/app/pages/fixture/fixture.component.scss
@@ -1,3 +1,7 @@
 .p-fixture {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex-grow: 1;
     padding: 1rem;
 }

--- a/src/app/pages/fixture/fixture.component.ts
+++ b/src/app/pages/fixture/fixture.component.ts
@@ -1,13 +1,15 @@
 import { Component } from '@angular/core';
 import { SharedModule } from '@app/shared/shared.module';
+import { UnderConstructionComponent } from '@app/components/under-construction/under-construction.component';
 
 @Component({
     standalone: true,
     selector: 'app-fixture',
-    imports: [SharedModule],
+    imports: [SharedModule, UnderConstructionComponent],
     template: `
         <div class="p-fixture">
             <h1>{{ 'PAGES.FIXTURE.NAME' | translate }}</h1>
+            <app-under-construction></app-under-construction>
         </div>
     `,
     styleUrls: ['./fixture.component.scss']

--- a/src/app/pages/forge/forge.component.scss
+++ b/src/app/pages/forge/forge.component.scss
@@ -4,6 +4,10 @@
 
 }
 .p-forge {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex-grow: 1;
     &__title {
         @include tabs-content-title;
     }

--- a/src/app/pages/forge/forge.component.ts
+++ b/src/app/pages/forge/forge.component.ts
@@ -1,14 +1,16 @@
 // src/app/pages/home/home.component.ts
 import { Component } from '@angular/core';
 import { SharedModule } from '@app/shared/shared.module';
+import { UnderConstructionComponent } from '@app/components/under-construction/under-construction.component';
 
 @Component({
     standalone: true,
     selector: 'app-forge',
-    imports: [SharedModule],
+    imports: [SharedModule, UnderConstructionComponent],
     template: `
         <section class="p-forge">
             <span class="p-forge__title">Forge</span>
+            <app-under-construction></app-under-construction>
         </section>
     `,
     styleUrls: ['./forge.component.scss']

--- a/src/app/pages/horseshoes/horseshoes.component.scss
+++ b/src/app/pages/horseshoes/horseshoes.component.scss
@@ -1,6 +1,10 @@
 @use 'mixin' as *;
 
 .p-horseshoes {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex-grow: 1;
     &__title {
         @include tabs-content-title;
     }

--- a/src/app/pages/horseshoes/horseshoes.component.ts
+++ b/src/app/pages/horseshoes/horseshoes.component.ts
@@ -1,13 +1,15 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 import { SharedModule } from '@app/shared/shared.module';
+import { UnderConstructionComponent } from '@app/components/under-construction/under-construction.component';
 
 @Component({
     standalone: true,
     selector: 'app-horseshoes',
-    imports: [SharedModule],
+    imports: [SharedModule, UnderConstructionComponent],
     template: `
         <section class="p-horseshoes">
             <span class="p-horseshoes__title">{{ 'PAGES.SHOP.SHOES.NAME' | translate }}</span>
+            <app-under-construction></app-under-construction>
         </section>
     `,
     styleUrls: ['./horseshoes.component.scss'],

--- a/src/app/pages/inventory/inventory.component.scss
+++ b/src/app/pages/inventory/inventory.component.scss
@@ -1,6 +1,10 @@
 @use 'mixin' as *;
 
 .p-inventory {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex-grow: 1;
     &__title {
         @include tabs-content-title;
     }

--- a/src/app/pages/inventory/inventory.component.ts
+++ b/src/app/pages/inventory/inventory.component.ts
@@ -1,13 +1,15 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 import { SharedModule } from '@app/shared/shared.module';
+import { UnderConstructionComponent } from '@app/components/under-construction/under-construction.component';
 
 @Component({
     standalone: true,
     selector: 'app-inventory',
-    imports: [SharedModule],
+    imports: [SharedModule, UnderConstructionComponent],
     template: `
         <section class="p-inventory">
             <span class="p-inventory__title">{{ 'PAGES.REFUGE.INVENTORY.NAME' | translate }}</span>
+            <app-under-construction></app-under-construction>
         </section>
     `,
     styleUrls: ['./inventory.component.scss'],

--- a/src/app/pages/jockeys/jockeys.component.scss
+++ b/src/app/pages/jockeys/jockeys.component.scss
@@ -1,6 +1,10 @@
 @use 'mixin' as *;
 
 .p-jockeys {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex-grow: 1;
     &__title {
         @include tabs-content-title;
     }

--- a/src/app/pages/jockeys/jockeys.component.ts
+++ b/src/app/pages/jockeys/jockeys.component.ts
@@ -1,13 +1,15 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 import { SharedModule } from '@app/shared/shared.module';
+import { UnderConstructionComponent } from '@app/components/under-construction/under-construction.component';
 
 @Component({
     standalone: true,
     selector: 'app-jockeys',
-    imports: [SharedModule],
+    imports: [SharedModule, UnderConstructionComponent],
     template: `
         <section class="p-jockeys">
             <span class="p-jockeys__title">{{ 'PAGES.SHOP.JOCKEYS.NAME' | translate }}</span>
+            <app-under-construction></app-under-construction>
         </section>
     `,
     styleUrls: ['./jockeys.component.scss'],

--- a/src/app/pages/paddock/paddock.component.scss
+++ b/src/app/pages/paddock/paddock.component.scss
@@ -1,6 +1,10 @@
 @use 'mixin' as *;
 
 .p-paddock {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex-grow: 1;
     &__title {
         @include tabs-content-title;
     }

--- a/src/app/pages/paddock/paddock.component.ts
+++ b/src/app/pages/paddock/paddock.component.ts
@@ -1,13 +1,15 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 import { SharedModule } from '@app/shared/shared.module';
+import { UnderConstructionComponent } from '@app/components/under-construction/under-construction.component';
 
 @Component({
     standalone: true,
     selector: 'app-paddock',
-    imports: [SharedModule],
+    imports: [SharedModule, UnderConstructionComponent],
     template: `
         <section class="p-paddock">
             <span class="p-paddock__title">{{ 'PAGES.REFUGE.PADDOCK.NAME' | translate }}</span>
+            <app-under-construction></app-under-construction>
         </section>
     `,
     styleUrls: ['./paddock.component.scss'],

--- a/src/app/pages/trading/trading.component.scss
+++ b/src/app/pages/trading/trading.component.scss
@@ -2,9 +2,14 @@
 
 app-trading {
     @include page;
+    justify-content: flex-start;
 }
 
 .p-trading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex-grow: 1;
     &__title {
         @include tabs-content-title;
     }

--- a/src/app/pages/trading/trading.component.ts
+++ b/src/app/pages/trading/trading.component.ts
@@ -1,15 +1,17 @@
 // src/app/pages/home/home.component.ts
 import { Component } from '@angular/core';
 import { SharedModule } from '@app/shared/shared.module';
+import { UnderConstructionComponent } from '@app/components/under-construction/under-construction.component';
 
 
 @Component({
     standalone: true,
     selector: 'app-trading',
-    imports: [SharedModule],
+    imports: [SharedModule, UnderConstructionComponent],
     template: `
         <section class="p-trading">
             <span class="p-trading__title">Trading</span>
+            <app-under-construction></app-under-construction>
         </section>
     `,
     styleUrls: ['./trading.component.scss']


### PR DESCRIPTION
## Summary
- add `UnderConstructionComponent` displaying a centered under construction image
- show the placeholder on accessories, fixture, forge, horseshoes, inventory, jockeys, paddock and trading pages
- style pages so the image fills remaining space beneath titles

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a76f2bbdd083209b65f58bb2e873e8