### PR TITLE
Enable external toggle for lock switch

### DIFF
--- a/src/app/components/lock-switch/lock-switch.component.html
+++ b/src/app/components/lock-switch/lock-switch.component.html
@@ -1,9 +1,21 @@
 <div class="c-lock-switch">
-    <p-toggleswitch [(ngModel)]="current_state">
+    <p-toggleswitch [(ngModel)]="current_state" (ngModelChange)="onToggleChange($event)">
         <ng-template #handle let-checked="checked">
             <i [ngClass]="['!text-xs', 'pi', checked ? 'pi-lock-open' : 'pi-lock']"></i>
         </ng-template>
     </p-toggleswitch>
-    <span *ngIf="current_state" class="c-lock-switch__text c-lock-switch__text--unlocked">{{ unlockedText }}</span>
-    <span *ngIf="!current_state" class="c-lock-switch__text c-lock-switch__text--locked">{{ lockedText }}</span>
+    <span
+        *ngIf="current_state"
+        class="c-lock-switch__text c-lock-switch__text--unlocked"
+        (click)="toggle()"
+    >
+        {{ unlockedText }}
+    </span>
+    <span
+        *ngIf="!current_state"
+        class="c-lock-switch__text c-lock-switch__text--locked"
+        (click)="toggle()"
+    >
+        {{ lockedText }}
+    </span>
 </div>

--- a/src/app/components/lock-switch/lock-switch.component.scss
+++ b/src/app/components/lock-switch/lock-switch.component.scss
@@ -4,6 +4,7 @@
     gap: 10px;
 
     &__text {
+        cursor: pointer;
         &--locked {
             color: var(--c-accent-2);
         }

--- a/src/app/components/lock-switch/lock-switch.component.ts
+++ b/src/app/components/lock-switch/lock-switch.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, Output } from '@angular/core';
+import { Component, Input, forwardRef } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { SharedModule } from '@app/shared/shared.module';
 import { ProgressBarModule } from 'primeng/progressbar';
 import { ToggleSwitchModule } from 'primeng/toggleswitch';
@@ -12,11 +13,44 @@ import { ToggleSwitchModule } from 'primeng/toggleswitch';
         ToggleSwitchModule
     ],
     templateUrl: './lock-switch.component.html',
-    styleUrls: ['./lock-switch.component.scss']
+    styleUrls: ['./lock-switch.component.scss'],
+    providers: [
+        {
+            provide: NG_VALUE_ACCESSOR,
+            useExisting: forwardRef(() => LockSwitchComponent),
+            multi: true
+        }
+    ]
 })
-export class LockSwitchComponent {
+export class LockSwitchComponent implements ControlValueAccessor {
     @Input() lockedText: string;
     @Input() unlockedText: string;
+
     current_state = false;
+
+    private onChange: (value: boolean) => void = () => {};
+    private onTouched: () => void = () => {};
+
+    writeValue(value: boolean): void {
+        this.current_state = value;
+    }
+
+    registerOnChange(fn: (value: boolean) => void): void {
+        this.onChange = fn;
+    }
+
+    registerOnTouched(fn: () => void): void {
+        this.onTouched = fn;
+    }
+
+    onToggleChange(value: boolean): void {
+        this.current_state = value;
+        this.onChange(value);
+        this.onTouched();
+    }
+
+    toggle(): void {
+        this.onToggleChange(!this.current_state);
+    }
 }
 


### PR DESCRIPTION
## Summary
- Integrate lock switch with Angular forms by implementing ControlValueAccessor
- Make lock/unlock text clickable and propagating value changes
- Show pointer cursor for toggle text

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ab5db196bc8320bf06dd591a8ecd50