### PR TITLE
Use category names for token metadata image paths

### DIFF
--- a/contracts/HorseStats.sol
+++ b/contracts/HorseStats.sol
@@ -75,6 +75,11 @@ contract HorseStats {
         return horseVisuals.getImgCategoryIds();
     }
 
+    function getImgCategoryName(uint256 imgCategory) external view returns (string memory) {
+        VisualsLib.ImgCategoryData storage data = horseVisuals.imgCategories[imgCategory];
+        return data.name;
+    }
+
     // ---------------------------------------------------------------------
     // Horse mutations (only controller)
     // ---------------------------------------------------------------------

--- a/contracts/HorseshoeStats.sol
+++ b/contracts/HorseshoeStats.sol
@@ -68,6 +68,11 @@ contract HorseshoeStats {
         return shoeVisuals.getImgCategoryIds();
     }
 
+    function getImgCategoryName(uint256 imgCategory) external view returns (string memory) {
+        VisualsLib.ImgCategoryData storage data = shoeVisuals.imgCategories[imgCategory];
+        return data.name;
+    }
+
     /// @notice Random visual usable by the controller (same signature as in HorseStats).
     function getRandomVisual(uint256 entropy) external view onlySpeedStats returns (uint256, uint256) {
         return shoeVisuals.getRandomVisual(entropy);

--- a/contracts/SpeedStats.sol
+++ b/contracts/SpeedStats.sol
@@ -364,12 +364,15 @@ contract SpeedStats {
             )
         );
 
+        string memory categoryName = horseModule.getImgCategoryName(data.imgCategory);
+        string memory categoryPath = _categoryPathSegment(categoryName, data.imgCategory);
+
         string memory json = string(
             abi.encodePacked(
                 '{',
                 '"name":"Speed Horse #', horseId.toString(), '",',
                 '"description":"Composite statistics between the horse and its equipped horseshoes.",',
-                '"image":"ipfs://category/', data.imgCategory.toString(), '/', data.imgNumber.toString(), '",',
+                '"image":"ipfs://category/', categoryPath, '/', data.imgNumber.toString(), '",',
                 '"level":', getLevel(horseId).toString(), ',',
                 '"totalPoints":', getTotalPoints(horseId).toString(), ',',
                 '"attributes":', attributes,
@@ -399,12 +402,15 @@ contract SpeedStats {
 
         attributes = string(abi.encodePacked(attributes, ']'));
 
+        string memory categoryName = horseshoeModule.getImgCategoryName(data.imgCategory);
+        string memory categoryPath = _categoryPathSegment(categoryName, data.imgCategory);
+
         string memory json = string(
             abi.encodePacked(
                 '{',
                 '"name":"Horseshoe #', horseshoeId.toString(), '",',
                 '"description":"A horseshoe that can be equipped to a Speed Horse to enhance its performance.",',
-                '"image":"ipfs://category/', data.imgCategory.toString(), '/', data.imgNumber.toString(), '",',
+                '"image":"ipfs://category/', categoryPath, '/', data.imgNumber.toString(), '",',
                 '"attributes":', attributes,
                 '}'
             )
@@ -419,6 +425,17 @@ contract SpeedStats {
 
     function _attributeJson(string memory trait, uint256 value) internal pure returns (string memory) {
         return string(abi.encodePacked('{"trait_type":"', trait, '","value":', value.toString(), '}'));
+    }
+
+    function _categoryPathSegment(string memory categoryName, uint256 fallbackId)
+        internal
+        pure
+        returns (string memory)
+    {
+        if (bytes(categoryName).length > 0) {
+            return categoryName;
+        }
+        return fallbackId.toString();
     }
 
     function _appendAttributeIfNonZero(


### PR DESCRIPTION
## Summary
- expose image category names from the horse and horseshoe stat modules
- use category names when building metadata image URIs, falling back to numeric ids if unnamed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc03926b1483209d56f63ed9a958bc