### PR TITLE
Update horseshoe creation to include visual configuration

### DIFF
--- a/contracts/HorseshoeStats.sol
+++ b/contracts/HorseshoeStats.sol
@@ -84,6 +84,8 @@ contract HorseshoeStats {
 
     function createHorseshoe(
         uint256 horseshoeId,
+        uint256 imgCategory,
+        uint256 imgNumber,
         PerformanceStats calldata bonusStats,
         uint256 maxDurability
     ) external onlySpeedStats {
@@ -91,28 +93,15 @@ contract HorseshoeStats {
         require(data.maxDurability == 0, "HorseshoeStats: horseshoe exists");
         require(maxDurability > 0, "HorseshoeStats: invalid durability");
 
-        // visuals will be set later via setHorseshoeImage (keeps signature stable)
-        data.imgCategory = 0;
-        data.imgNumber = 0;
+        VisualsLib.ImgCategoryData storage cat = shoeVisuals.imgCategories[imgCategory];
+        require(cat.exists && imgNumber >= 1 && imgNumber <= cat.maxImgNumber, "HorseshoeStats: invalid image");
+
+        data.imgCategory = imgCategory;
+        data.imgNumber = imgNumber;
 
         data.bonusStats = bonusStats;
         data.maxDurability = maxDurability;
         data.durabilityUsed = maxDurability; // as per your current semantics
-    }
-
-    /// @notice Sets the image for a given horseshoe (restricted to controller).
-    function setHorseshoeImage(
-        uint256 horseshoeId,
-        uint256 imgCategory,
-        uint256 imgNumber
-    ) external onlySpeedStats {
-        HorseshoeData storage data = horseshoes[horseshoeId];
-        require(data.maxDurability > 0, "HorseshoeStats: unknown horseshoe");
-        // Optional guards: ensure category exists and number is within range
-        VisualsLib.ImgCategoryData storage cat = shoeVisuals.imgCategories[imgCategory];
-        require(cat.exists && imgNumber >= 1 && imgNumber <= cat.maxImgNumber, "HorseshoeStats: invalid image");
-        data.imgCategory = imgCategory;
-        data.imgNumber = imgNumber;
     }
 
     function restore(uint256 horseshoeId) external onlySpeedStats {

--- a/contracts/SpeedStats.sol
+++ b/contracts/SpeedStats.sol
@@ -179,7 +179,13 @@ contract SpeedStats {
     // ---------------------------------------------------------------------
 
     /// @dev maxAdjustments removed to match HorseshoeStats; event updated accordingly.
-    event HorseshoeCreated(uint256 indexed horseshoeId, PerformanceStats bonusStats, uint256 maxDurability);
+    event HorseshoeCreated(
+        uint256 indexed horseshoeId,
+        uint256 imgCategory,
+        uint256 imgNumber,
+        PerformanceStats bonusStats,
+        uint256 maxDurability
+    );
     event HorseshoeEquipped(uint256 indexed horseId, uint256 indexed horseshoeId);
     event HorseshoeUnequipped(uint256 indexed horseId, uint256 indexed horseshoeId);
 
@@ -196,11 +202,13 @@ contract SpeedStats {
     /// @notice Create a new horseshoe record in the module (admin operation).
     function createHorseshoe(
         uint256 horseshoeId,
+        uint256 imgCategory,
+        uint256 imgNumber,
         PerformanceStats calldata bonusStats,
         uint256 maxDurability
     ) external onlyAdmin {
-        horseshoeModule.createHorseshoe(horseshoeId, bonusStats, maxDurability);
-        emit HorseshoeCreated(horseshoeId, bonusStats, maxDurability);
+        horseshoeModule.createHorseshoe(horseshoeId, imgCategory, imgNumber, bonusStats, maxDurability);
+        emit HorseshoeCreated(horseshoeId, imgCategory, imgNumber, bonusStats, maxDurability);
     }
 
     /// @notice Equip a horseshoe into one of the limited slots of the horse.


### PR DESCRIPTION
## Summary
- allow horseshoe creation to receive image category/number and validate them inside `HorseshoeStats`
- wire the new arguments through `SpeedStats` and extend the creation event payload

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd6d42f60c83208610ce4d6135a03c