### PR TITLE
Rename smart contracts with SpeedH prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ https://lucide.dev/icons/
 code node_modules/lucide-angular/icons/lucide-icons.d.ts
 ```
 
-https://github.com/vapaee/speed-horses/blob/11a8b9f2cce2c4f754a87721d8013fb0c87da9ee/contracts/HorseStats.sol
+https://github.com/vapaee/speed-horses/blob/11a8b9f2cce2c4f754a87721d8013fb0c87da9ee/contracts/SpeedH_Stats_Horse.sol

--- a/contracts/SpeedH_FixtureManager.sol
+++ b/contracts/SpeedH_FixtureManager.sol
@@ -6,16 +6,16 @@ interface IHorses {
     function getTotalPoints(uint256 horseId) external view returns (uint256 points);
 }
 
-/// @title FixtureManager
+/// @title SpeedH_FixtureManager
 /// @notice Manages race fixtures and horse registrations.
 /// @dev This is a simplified implementation based on the provided specification.
 /**
- * Título: FixtureManager
+ * Título: SpeedH_FixtureManager
  * Brief: Orquestador de las carreras que se encarga de recibir inscripciones, organizar caballos por puntaje y armar las tandas de competencias respetando capacidades, tiempos y compensaciones. Administra el ciclo de vida de cada fixture desde su creación hasta su confirmación, calculando longitudes de pista y premios de consolación mientras coordina con el contrato de estadísticas y el token HAY.
  * API: los jugadores interactúan mediante `registerHorse`, que dispara internamente `_tryGenerateFixture` para avanzar en el proceso de armado; el contrato expone utilidades privadas (`_calculateNextStartTime`, `_calculateRaceLength`, `_min`) que determinan horarios y distancias de las carreras, y mantiene getters como `isRegistered` para consultas externas. Las funciones administrativas (`setHorseStats`, `setHayToken`) conectan las dependencias necesarias, completando el flujo de preparación de fixtures antes de las simulaciones de carrera.
  */
-contract FixtureManager {
-    string public version = "FixtureManager-v1.0.0";
+contract SpeedH_FixtureManager {
+    string public version = "SpeedH_FixtureManager-v1.0.0";
 
     // ---------------------------------------------------------------------
     // Contract References

--- a/contracts/SpeedH_FoalForge.sol
+++ b/contracts/SpeedH_FoalForge.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import { PerformanceStats } from "./StatsStructs.sol";
+import { PerformanceStats } from "./SpeedH_StatsStructs.sol";
 
-interface IHorseStats {
+interface ISpeedH_Stats_Horse {
     function createHorse(uint256 horseId, uint256 imgCategory, uint256 imgNumber, PerformanceStats calldata baseStats) external;
     function getRandomVisual(uint256 entropy) external view returns (uint256 imgCategory, uint256 imgNumber);
     function getRandomHorseshoeVisual(uint256 entropy) external view returns (uint256 imgCategory, uint256 imgNumber);
@@ -17,29 +17,29 @@ interface IHorseStats {
     ) external;
 }
 
-interface ISpeedHorses {
+interface ISpeedH_NFT_Horse {
     function mint(address to, uint256 horseId) external;
 }
 
-interface IHorseshoes {
+interface ISpeedH_NFT_Horseshoe {
     function mint(address to, uint256 horseshoeId) external;
 }
 
 /**
- * Título: HorseMinter
+ * Título: SpeedH_FoalForge
  * Brief: Coordinador del proceso de creación de caballos que cobra tarifas en TLOS y genera las combinaciones iniciales de categorías de imagen y estadísticas para cada jugador antes de acuñar el NFT y registrar sus atributos definitivos. Gestiona el flujo de construcción incremental, contabiliza los paquetes de puntos extra adquiridos y comunica los resultados al contrato de estadísticas y al ERC-721 del juego.
  * API: ofrece funciones públicas que modelan el proceso de minteo en etapas (`startHorseMint`, `randomizeHorse`, `buyExtraPoints`, `claimHorse`), cada una avanzando el estado del caballo pendiente y validando pagos y límites; incluye utilidades pseudoaleatorias para categorías de imagen y estadísticas (`_randomHorseStats`, `_randomVisual`, `_randomize`) utilizadas durante dicho proceso. El administrador conecta dependencias y gestiona fondos mediante `setHorseStats`, `setSpeedHorses` y `withdrawTLOS`, completando así el circuito operativo del minter.
  */
-contract HorseMinter {
-    string public version = "HorseMinter-v1.1.0";
+contract SpeedH_FoalForge {
+    string public version = "SpeedH_FoalForge-v1.1.0";
 
     // ---------------------------------------------------------------------
     // Contract References
     // ---------------------------------------------------------------------
     address public admin;
-    IHorseStats public horseStats;
-    ISpeedHorses public speedHorses;
-    IHorseshoes public horseshoes;
+    ISpeedH_Stats_Horse public horseStats;
+    ISpeedH_NFT_Horse public speedHorses;
+    ISpeedH_NFT_Horseshoe public horseshoes;
 
     // ---------------------------------------------------------------------
     // Constants
@@ -119,7 +119,7 @@ contract HorseMinter {
         HorseBuild storage build = pendingHorse[msg.sender];
         require(build.totalPoints != 0, 'No horse to claim');
 
-        require(address(horseshoes) != address(0), 'Horseshoes not set');
+        require(address(horseshoes) != address(0), 'SpeedH_NFT_Horseshoe not set');
 
         uint256 horseId = nextHorseId++;
         speedHorses.mint(msg.sender, horseId);
@@ -260,15 +260,15 @@ contract HorseMinter {
     // ----------------------------------------------------
 
     function setHorseStats(address _stats) external onlyAdmin {
-        horseStats = IHorseStats(_stats);
+        horseStats = ISpeedH_Stats_Horse(_stats);
     }
 
     function setSpeedHorses(address _horses) external onlyAdmin {
-        speedHorses = ISpeedHorses(_horses);
+        speedHorses = ISpeedH_NFT_Horse(_horses);
     }
 
     function setHorseshoes(address _horseshoes) external onlyAdmin {
-        horseshoes = IHorseshoes(_horseshoes);
+        horseshoes = ISpeedH_NFT_Horseshoe(_horseshoes);
     }
 
     function withdrawTLOS(address payable to, uint256 amount) external onlyAdmin {

--- a/contracts/SpeedH_HayToken.sol
+++ b/contracts/SpeedH_HayToken.sol
@@ -5,12 +5,12 @@ import { ERC20 } from '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
 
 /**
- * Título: HayToken
+ * Título: SpeedH_HayToken
  * Brief: Token ERC-20 nativo del ecosistema utilizado para pagos internos como inscripciones, alimentación y recompensas dentro del juego. Está controlado por una cuenta dueña que puede administrar emisiones o políticas futuras a través de las capacidades del contrato base.
  * API: hereda la interfaz estándar de ERC-20 provista por OpenZeppelin (transferencias, aprobaciones, consultas de saldo y supply) y utiliza `Ownable` para exponer funciones administrativas como `transferOwnership`. Su constructor define el nombre y símbolo utilizados en todas las interacciones económicas del proyecto.
  */
-contract HayToken is ERC20, Ownable {
-    string public version = "HayToken-v1.0.0";
+contract SpeedH_HayToken is ERC20, Ownable {
+    string public version = "SpeedH_HayToken-v1.0.0";
 
     constructor()
         ERC20('HAY Token', 'HAY')

--- a/contracts/SpeedH_HayTokenOFT.sol
+++ b/contracts/SpeedH_HayTokenOFT.sol
@@ -12,12 +12,12 @@ import '@layerzerolabs/lz-evm-oapp-v2/contracts/oft/OFT.sol';
 // More here: https://docs.layerzero.network/v2/deployments/deployed-contracts
 
 /**
- * Título: HayTokenOFT
+ * Título: SpeedH_HayTokenOFT
  * Brief: Versión omnichain del token HAY basada en LayerZero que habilita transferencias entre cadenas mientras conserva control de propiedad. Sirve como puente entre ecosistemas, permitiendo que el activo utilitario del juego circule más allá de la red principal manteniendo registro del endpoint y el delegado del protocolo.
  * API: se apoya en las funciones de la clase `OFT` (envío y recepción entre cadenas, gestión de cuotas, etc.) y en `Ownable` para tareas administrativas como configurar el delegado. Su constructor establece los parámetros de despliegue (`_lzEndpoint`, `_delegate`, `_initialOwner`), integrando el token a los flujos de mensajería de LayerZero usados en procesos de interoperabilidad.
  */
-contract HayTokenOFT is Ownable, OFT {
-    string public version = "HayTokenOFT-v1.0.0";
+contract SpeedH_HayTokenOFT is Ownable, OFT {
+    string public version = "SpeedH_HayTokenOFT-v1.0.0";
     constructor(
         address _lzEndpoint,
         address _delegate,

--- a/contracts/SpeedH_NFT_Horse.sol
+++ b/contracts/SpeedH_NFT_Horse.sol
@@ -5,12 +5,12 @@ import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
 import '@openzeppelin/contracts/access/Ownable.sol';
 
 /**
- * Título: SpeedHorses
+ * Título: SpeedH_NFT_Horse
  * Brief: Contrato ERC-721 que representa a los caballos del juego, delega la generación de metadatos y controles de transferencia al módulo de estadísticas y garantiza que sólo el administrador y el minter autorizado puedan acuñar o gestionar los tokens. Administra referencias cruzadas a los contratos que definen atributos y respeta las restricciones de descanso y registro en carreras antes de permitir movimientos.
  * API: expone funciones administrativas para definir los contratos auxiliares (`setHorseMinter`, `setHorseStats`), un punto de acuñación protegido (`mint`) y la consulta de metadatos (`tokenURI`). Además, sobreescribe `_update` para integrarse en el flujo de juego, verificando en las transferencias que el caballo haya terminado de descansar y que no esté inscrito en competencias, siendo esta validación una etapa previa a cualquier intercambio entre jugadores.
  */
-contract SpeedHorses is ERC721, Ownable {
-    string public version = "SpeedHorses-v1.0.0";
+contract SpeedH_NFT_Horse is ERC721, Ownable {
+    string public version = "SpeedH_NFT_Horse-v1.0.0";
 
     // ---------------------------------------------------------------------
     // Contract References

--- a/contracts/SpeedH_NFT_Horseshoe.sol
+++ b/contracts/SpeedH_NFT_Horseshoe.sol
@@ -4,23 +4,22 @@ pragma solidity ^0.8.20;
 import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
 import '@openzeppelin/contracts/access/Ownable.sol';
 
-import './SpeedHorses.sol';
+import './SpeedH_NFT_Horse.sol';
 
 /**
- * Título: Horseshoes
+ * Título: SpeedH_NFT_Horseshoe
  * Brief: Contrato ERC-721 que representa las herraduras del ecosistema Speed Horses, permitiendo que el juego administre la
  * acuñación de piezas equipables para los caballos. Mantiene un control de acceso sencillo en el que solamente el administrador
  * o el minter autorizado pueden configurar dependencias y emitir nuevos NFTs.
  * API: expone operaciones administrativas para definir el minter (`setHorseMinter`) y un punto de acuñación restringido (`mint`)
- * que delega en el contrato `HorseMinter`. Hereda de `ERC721` y `Ownable` para integrarse sin fricción con el resto de módulos
- * on-chain.
+ * que delega en el contrato `SpeedH_FoalForge`. Hereda de `ERC721` y `Ownable` para integrarse sin fricción con el resto de módulos on-chain.
  */
-contract Horseshoes is ERC721, Ownable {
+contract SpeedH_NFT_Horseshoe is ERC721, Ownable {
     // ---------------------------------------------------------------------
     // Storage
     // ---------------------------------------------------------------------
 
-    string public version = 'Horseshoes-v1.0.0';
+    string public version = 'SpeedH_NFT_Horseshoe-v1.0.0';
 
     address public admin;
     address public horseMinter;

--- a/contracts/SpeedH_StatsStructs.sol
+++ b/contracts/SpeedH_StatsStructs.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 /**
- * Título: StatsStructs
+ * Título: SpeedH_StatsStructs
  * Brief: Definiciones de estructuras de datos compartidas que encapsulan tanto las estadísticas de rendimiento como los atributos de enfriamiento utilizados por múltiples contratos del juego para describir caballos y sus progresos.
  * API: proporciona los structs `PerformanceStats` y `CooldownStats`, que agrupan los campos necesarios para procesos de minteo, asignación de puntos, cálculo de niveles y descansos. Estos tipos se importan en los demás contratos para mantener una interfaz coherente en cada etapa del ciclo de vida del caballo.
  */

--- a/contracts/SpeedH_Stats_Horse.sol
+++ b/contracts/SpeedH_Stats_Horse.sol
@@ -1,30 +1,31 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import { PerformanceStats } from "./StatsStructs.sol";
-import { VisualsLib } from "./VisualsLib.sol";
+import { PerformanceStats } from "./SpeedH_StatsStructs.sol";
+import { SpeedH_VisualsLib } from "./SpeedH_VisualsLib.sol";
 
 /**
- * Title: HorseStats
+ * Title: SpeedH_Stats_Horse
  * Brief: Persistent storage for horses: visuals, base/assigned stats, points ledger and rest cooldown.
- *        Uses VisualsLib for category administration and random selection.
+ *        Uses SpeedH_VisualsLib for category administration and random selection.
  */
-contract HorseStats {
-    using VisualsLib for VisualsLib.VisualSpace;
+contract SpeedH_Stats_Horse {
+    using SpeedH_VisualsLib for SpeedH_VisualsLib.VisualSpace;
 
     // ---------------------------------------------------------------------
     // Roles
     // ---------------------------------------------------------------------
     address public owner;
     address public speedStats;
+    string public version = "SpeedH_Stats_Horse-v1.0.0";
 
     modifier onlyOwner() {
-        require(msg.sender == owner, "HorseStats: not owner");
+        require(msg.sender == owner, "SpeedH_Stats_Horse: not owner");
         _;
     }
 
     modifier onlySpeedStats() {
-        require(msg.sender == speedStats, "HorseStats: only controller");
+        require(msg.sender == speedStats, "SpeedH_Stats_Horse: only controller");
         _;
     }
 
@@ -33,12 +34,12 @@ contract HorseStats {
     }
 
     function setSpeedStats(address controller) external onlyOwner {
-        require(controller != address(0), "HorseStats: invalid controller");
+        require(controller != address(0), "SpeedH_Stats_Horse: invalid controller");
         speedStats = controller;
     }
 
     function transferOwnership(address newOwner) external onlyOwner {
-        require(newOwner != address(0), "HorseStats: invalid owner");
+        require(newOwner != address(0), "SpeedH_Stats_Horse: invalid owner");
         owner = newOwner;
     }
 
@@ -59,9 +60,9 @@ contract HorseStats {
     mapping(uint256 => HorseData) private horses;
 
     // ---------------------------------------------------------------------
-    // Visuals (for horses) via VisualsLib
+    // Visuals (for horses) via SpeedH_VisualsLib
     // ---------------------------------------------------------------------
-    VisualsLib.VisualSpace private horseVisuals;
+    SpeedH_VisualsLib.VisualSpace private horseVisuals;
 
     // Category administration (proxied to library)
     function setImgCategory(uint256 imgCategory, string calldata name, uint256 maxImgNumber)
@@ -76,7 +77,7 @@ contract HorseStats {
     }
 
     function getImgCategoryName(uint256 imgCategory) external view returns (string memory) {
-        VisualsLib.ImgCategoryData storage data = horseVisuals.imgCategories[imgCategory];
+        SpeedH_VisualsLib.ImgCategoryData storage data = horseVisuals.imgCategories[imgCategory];
         return data.name;
     }
 
@@ -91,7 +92,7 @@ contract HorseStats {
         PerformanceStats calldata baseStats
     ) external onlySpeedStats {
         HorseData storage h = horses[horseId];
-        require(!h.exists, "HorseStats: horse exists");
+        require(!h.exists, "SpeedH_Stats_Horse: horse exists");
 
         h.exists = true;
         h.imgCategory = imgCategory;
@@ -105,27 +106,27 @@ contract HorseStats {
 
     function addPoints(uint256 horseId, uint256 points) external onlySpeedStats {
         HorseData storage h = horses[horseId];
-        require(h.exists, "HorseStats: unknown horse");
+        require(h.exists, "SpeedH_Stats_Horse: unknown horse");
         h.totalPoints += points;
         h.unassignedPoints += points;
     }
 
     function consumeUnassigned(uint256 horseId, uint256 points) external onlySpeedStats {
         HorseData storage h = horses[horseId];
-        require(h.exists, "HorseStats: unknown horse");
-        require(h.unassignedPoints >= points, "HorseStats: not enough points");
+        require(h.exists, "SpeedH_Stats_Horse: unknown horse");
+        require(h.unassignedPoints >= points, "SpeedH_Stats_Horse: not enough points");
         h.unassignedPoints -= points;
     }
 
     function setAssignedStats(uint256 horseId, PerformanceStats calldata stats) external onlySpeedStats {
         HorseData storage h = horses[horseId];
-        require(h.exists, "HorseStats: unknown horse");
+        require(h.exists, "SpeedH_Stats_Horse: unknown horse");
         h.assignedStats = stats;
     }
 
     function setRestFinish(uint256 horseId, uint256 restFinish) external onlySpeedStats {
         HorseData storage h = horses[horseId];
-        require(h.exists, "HorseStats: unknown horse");
+        require(h.exists, "SpeedH_Stats_Horse: unknown horse");
         h.restFinish = restFinish;
     }
 
@@ -135,7 +136,7 @@ contract HorseStats {
 
     function getHorse(uint256 horseId) external view returns (HorseData memory) {
         HorseData memory h = horses[horseId];
-        require(h.exists, "HorseStats: unknown horse");
+        require(h.exists, "SpeedH_Stats_Horse: unknown horse");
         return h;
     }
 

--- a/contracts/SpeedH_Stats_Horseshoe.sol
+++ b/contracts/SpeedH_Stats_Horseshoe.sol
@@ -1,27 +1,28 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import { PerformanceStats } from "./StatsStructs.sol";
-import { VisualsLib } from "./VisualsLib.sol";
+import { PerformanceStats } from "./SpeedH_StatsStructs.sol";
+import { SpeedH_VisualsLib } from "./SpeedH_VisualsLib.sol";
 
 /**
- * Title: HorseshoeStats
+ * Title: SpeedH_Stats_Horseshoe
  * Brief: Lifecycle and storage of horseshoes: bonus stats, durability, and visuals.
- *        Uses VisualsLib for category administration and random selection.
+ *        Uses SpeedH_VisualsLib for category administration and random selection.
  */
-contract HorseshoeStats {
-    using VisualsLib for VisualsLib.VisualSpace;
+contract SpeedH_Stats_Horseshoe {
+    using SpeedH_VisualsLib for SpeedH_VisualsLib.VisualSpace;
 
     address public owner;
     address public speedStats;
+    string public version = "SpeedH_Stats_Horseshoe-v1.0.0";
 
     modifier onlyOwner() {
-        require(msg.sender == owner, "HorseshoeStats: not owner");
+        require(msg.sender == owner, "SpeedH_Stats_Horseshoe: not owner");
         _;
     }
 
     modifier onlySpeedStats() {
-        require(msg.sender == speedStats, "HorseshoeStats: only controller");
+        require(msg.sender == speedStats, "SpeedH_Stats_Horseshoe: only controller");
         _;
     }
 
@@ -30,12 +31,12 @@ contract HorseshoeStats {
     }
 
     function setSpeedStats(address controller) external onlyOwner {
-        require(controller != address(0), "HorseshoeStats: invalid controller");
+        require(controller != address(0), "SpeedH_Stats_Horseshoe: invalid controller");
         speedStats = controller;
     }
 
     function transferOwnership(address newOwner) external onlyOwner {
-        require(newOwner != address(0), "HorseshoeStats: invalid owner");
+        require(newOwner != address(0), "SpeedH_Stats_Horseshoe: invalid owner");
         owner = newOwner;
     }
 
@@ -52,9 +53,9 @@ contract HorseshoeStats {
     mapping(uint256 => HorseshoeData) private horseshoes;
 
     // ---------------------------------------------------------------------
-    // Visuals (for horseshoes) via VisualsLib
+    // Visuals (for horseshoes) via SpeedH_VisualsLib
     // ---------------------------------------------------------------------
-    VisualsLib.VisualSpace private shoeVisuals;
+    SpeedH_VisualsLib.VisualSpace private shoeVisuals;
 
     /// @notice Adds/updates image categories for horseshoes.
     function setImgCategory(uint256 imgCategory, string calldata name, uint256 maxImgNumber)
@@ -69,11 +70,11 @@ contract HorseshoeStats {
     }
 
     function getImgCategoryName(uint256 imgCategory) external view returns (string memory) {
-        VisualsLib.ImgCategoryData storage data = shoeVisuals.imgCategories[imgCategory];
+        SpeedH_VisualsLib.ImgCategoryData storage data = shoeVisuals.imgCategories[imgCategory];
         return data.name;
     }
 
-    /// @notice Random visual usable by the controller (same signature as in HorseStats).
+    /// @notice Random visual usable by the controller (same signature as in SpeedH_Stats_Horse).
     function getRandomVisual(uint256 entropy) external view onlySpeedStats returns (uint256, uint256) {
         return shoeVisuals.getRandomVisual(entropy);
     }
@@ -90,11 +91,11 @@ contract HorseshoeStats {
         uint256 maxDurability
     ) external onlySpeedStats {
         HorseshoeData storage data = horseshoes[horseshoeId];
-        require(data.maxDurability == 0, "HorseshoeStats: horseshoe exists");
-        require(maxDurability > 0, "HorseshoeStats: invalid durability");
+        require(data.maxDurability == 0, "SpeedH_Stats_Horseshoe: horseshoe exists");
+        require(maxDurability > 0, "SpeedH_Stats_Horseshoe: invalid durability");
 
-        VisualsLib.ImgCategoryData storage cat = shoeVisuals.imgCategories[imgCategory];
-        require(cat.exists && imgNumber >= 1 && imgNumber <= cat.maxImgNumber, "HorseshoeStats: invalid image");
+        SpeedH_VisualsLib.ImgCategoryData storage cat = shoeVisuals.imgCategories[imgCategory];
+        require(cat.exists && imgNumber >= 1 && imgNumber <= cat.maxImgNumber, "SpeedH_Stats_Horseshoe: invalid image");
 
         data.imgCategory = imgCategory;
         data.imgNumber = imgNumber;
@@ -106,20 +107,20 @@ contract HorseshoeStats {
 
     function restore(uint256 horseshoeId) external onlySpeedStats {
         HorseshoeData storage data = horseshoes[horseshoeId];
-        require(data.maxDurability > 0, "HorseshoeStats: unknown horseshoe");
+        require(data.maxDurability > 0, "SpeedH_Stats_Horseshoe: unknown horseshoe");
         data.durabilityUsed = data.maxDurability;
     }
 
     function consume(uint256 horseshoeId, uint256 less) external onlySpeedStats {
         HorseshoeData storage data = horseshoes[horseshoeId];
-        require(data.maxDurability > 0, "HorseshoeStats: unknown horseshoe");
-        require(less > data.durabilityUsed, "HorseshoeStats: insufficient durability");
+        require(data.maxDurability > 0, "SpeedH_Stats_Horseshoe: unknown horseshoe");
+        require(less > data.durabilityUsed, "SpeedH_Stats_Horseshoe: insufficient durability");
         data.durabilityUsed = data.durabilityUsed - less;
     }
 
     function getHorseshoe(uint256 horseshoeId) external view returns (HorseshoeData memory) {
         HorseshoeData memory data = horseshoes[horseshoeId];
-        require(data.maxDurability > 0, "HorseshoeStats: unknown horseshoe");
+        require(data.maxDurability > 0, "SpeedH_Stats_Horseshoe: unknown horseshoe");
         return data;
     }
 }

--- a/contracts/SpeedH_UFix6Lib.sol
+++ b/contracts/SpeedH_UFix6Lib.sol
@@ -10,11 +10,11 @@ pragma solidity ^0.8.20;
 type UFix6 is uint256;
 
 /**
- * Título: UFix6Lib
+ * Título: SpeedH_UFix6Lib
  * Brief: Biblioteca matemática que implementa aritmética de punto fijo con seis decimales y utilidades logarítmicas necesarias para calcular niveles y escalados dentro del sistema de estadísticas de caballos. Centraliza las operaciones seguras para transformar valores enteros en representaciones fraccionarias sin perder precisión en cálculos recurrentes.
- * API: expone constructores (`fromUint`, `wrapRaw`, `fromParts`), conversores (`toUint`, `raw`), operaciones básicas (`add`, `sub`, `mul`, `mulUint`, `div`, `divUint`), constantes (`one`) y funciones logarítmicas (`ilog2`, `log2_uint`, `log2`). Estas rutinas son utilizadas por contratos como `HorseStats` para determinar niveles y tiempos de descanso dentro de los procesos de progresión del juego.
+ * API: expone constructores (`fromUint`, `wrapRaw`, `fromParts`), conversores (`toUint`, `raw`), operaciones básicas (`add`, `sub`, `mul`, `mulUint`, `div`, `divUint`), constantes (`one`) y funciones logarítmicas (`ilog2`, `log2_uint`, `log2`). Estas rutinas son utilizadas por contratos como `SpeedH_Stats_Horse` para determinar niveles y tiempos de descanso dentro de los procesos de progresión del juego.
  */
-library UFix6Lib {
+library SpeedH_UFix6Lib {
     uint256 internal constant SCALE = 1e6;
     uint256 internal constant TWO_SCALE = 2 * SCALE;
 
@@ -145,17 +145,17 @@ library UFix6Lib {
 
 /*
 library LogMath {
-    using UFix6Lib for UFix6;
+    using SpeedH_UFix6Lib for UFix6;
 
     // result = K * log2(x), with x as uint (1..1000), returns UFix6
     function kMulLog2_uint(uint256 K, uint256 x) internal pure returns (UFix6) {
-        UFix6 lx = UFix6Lib.log2_uint(x);         // UFix6
+        UFix6 lx = SpeedH_UFix6Lib.log2_uint(x);         // UFix6
         return lx.mulUint(K);                      // still UFix6
     }
 
     // result = K * log2(x), with x as UFix6, returns UFix6
     function kMulLog2_ufix(uint256 K, UFix6 x) internal pure returns (UFix6) {
-        UFix6 lx = UFix6Lib.log2(x);
+        UFix6 lx = SpeedH_UFix6Lib.log2(x);
         return lx.mulUint(K);
     }
 }
@@ -163,20 +163,20 @@ library LogMath {
 // ---------- Example usage ----------
 
 contract LogExample {
-    using UFix6Lib for UFix6;
+    using SpeedH_UFix6Lib for UFix6;
 
     uint256 public constant K = 100;
 
     function resultFor(uint256 x) external pure returns (uint256 resultScaled, uint256 resultInteger) {
         // x is plain integer in [1..1000]
         UFix6 r = LogMath.kMulLog2_uint(K, x);      // UFix6 (scale 1e6)
-        resultScaled = UFix6Lib.raw(r);             // scaled by 1e6
+        resultScaled = SpeedH_UFix6Lib.raw(r);             // scaled by 1e6
         resultInteger = r.toUint();                 // truncated integer part
     }
     function resultForUFix6(UFix6 x) external pure returns (uint256 resultScaled, uint256 resultInteger) {
         // x is UFix6 (scale 1e6)
         UFix6 r = LogMath.kMulLog2_ufix(K, x);      // UFix6 (scale 1e6)
-        resultScaled = UFix6Lib.raw(r);             // scaled by 1e6
+        resultScaled = SpeedH_UFix6Lib.raw(r);             // scaled by 1e6
         resultInteger = r.toUint();                 // truncated integer part
     }
 }

--- a/contracts/SpeedH_VisualsLib.sol
+++ b/contracts/SpeedH_VisualsLib.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-/// @title VisualsLib
+/// @title SpeedH_VisualsLib
 /// @notice Reusable storage & helpers to manage image categories and random visual selection.
-library VisualsLib {
+library SpeedH_VisualsLib {
     struct ImgCategoryData {
         string name;
         uint256 maxImgNumber;
@@ -51,7 +51,7 @@ library VisualsLib {
         VisualSpace storage vs,
         uint256 entropy
     ) internal view returns (uint256 imgCategory, uint256 imgNumber) {
-        require(vs.imgCategoryIds.length > 0, "VisualsLib: no categories");
+        require(vs.imgCategoryIds.length > 0, "SpeedH_VisualsLib: no categories");
 
         uint256 validCategories = 0;
         uint256 length = vs.imgCategoryIds.length;
@@ -61,7 +61,7 @@ library VisualsLib {
                 validCategories++;
             }
         }
-        require(validCategories > 0, "VisualsLib: categories empty");
+        require(validCategories > 0, "SpeedH_VisualsLib: categories empty");
 
         uint256 categorySeed = uint256(
             keccak256(abi.encodePacked(block.timestamp, block.prevrandao, entropy))
@@ -80,7 +80,7 @@ library VisualsLib {
                 counter++;
             }
         }
-        require(selectedCategory != type(uint256).max, "VisualsLib: invalid selection");
+        require(selectedCategory != type(uint256).max, "SpeedH_VisualsLib: invalid selection");
 
         ImgCategoryData storage chosen = vs.imgCategories[selectedCategory];
         uint256 numberSeed = uint256(keccak256(abi.encodePacked(categorySeed, entropy, block.number)));

--- a/docs/HAY-draft.md
+++ b/docs/HAY-draft.md
@@ -1,4 +1,4 @@
 Token HAY (alimento de caballos)
 
-El contrato inteligente HayToken implementa el estandard ERC20 con una pequeña lista de particularidades:
+El contrato inteligente SpeedH_HayToken implementa el estandard ERC20 con una pequeña lista de particularidades:
 1 - 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,8 +1,8 @@
 # Deploy
-- HayTokenOFT.sol
-- SpeedHorses.sol
-- HorseStats.sol
-- HorseMinter.sol
+- SpeedH_HayTokenOFT.sol
+- SpeedH_NFT_Horse.sol
+- SpeedH_Stats_Horse.sol
+- SpeedH_FoalForge.sol
 
 
 


### PR DESCRIPTION
## Summary
- rename all Solidity contracts to use the SpeedH_* naming scheme and update each contract/class declaration accordingly
- refresh version identifiers, imports, and helper interfaces to align with the new contract names
- update supporting documentation links and deployment notes to reference the renamed contracts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ded168486c8320839f5d0d815fc932