### PR TITLE
feat: add horseshoe fusion and repair minters

### DIFF
--- a/contracts/SpeedH_Minter_AnvilAlchemy.sol
+++ b/contracts/SpeedH_Minter_AnvilAlchemy.sol
@@ -1,0 +1,439 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+import { PerformanceStats } from "./SpeedH_StatsStructs.sol";
+import { SpeedH_Stats_Horseshoe } from "./SpeedH_Stats_Horseshoe.sol";
+
+interface ISpeedH_Stats_Fusion {
+    function horseshoeModule() external view returns (SpeedH_Stats_Horseshoe);
+    function isHorseshoeEquipped(uint256 horseshoeId) external view returns (bool);
+    function getRandomHorseshoeVisual(uint256 entropy) external view returns (uint256, uint256);
+    function registerForgedHorseshoe(
+        uint256 horseshoeId,
+        uint256 imgCategory,
+        uint256 imgNumber,
+        PerformanceStats calldata bonusStats,
+        uint256 maxDurability,
+        uint256 level,
+        bool pure
+    ) external;
+}
+
+interface ISpeedH_NFT_Horseshoe_MintBurn is IERC721 {
+    function mint(address to) external returns (uint256);
+    function burn(uint256 tokenId) external;
+}
+
+/**
+ * @title SpeedH_Minter_AnvilAlchemy
+ * @notice Implements the multi-stage workflow required to fuse two existing horseshoes into a new one.
+ *         Users start the process paying in TLOS, randomize as many times as desired paying in HAY and
+ *         finally claim the resulting NFT, which burns the two parents and mints a higher level successor.
+ *         Cancellation is supported, returning the deposited NFTs and most of the upfront cost.
+ */
+contract SpeedH_Minter_AnvilAlchemy {
+    // ---------------------------------------------------------------------
+    // Configuration
+    // ---------------------------------------------------------------------
+
+    address public admin;
+    ISpeedH_Stats_Fusion public speedStats;
+    ISpeedH_NFT_Horseshoe_MintBurn public horseshoeNft;
+    IERC20 public hayToken;
+
+    uint256 public fusionTlosCost = 400 ether;
+    uint256 public randomizeHayCost = 40 ether;
+    uint256 public parentError = 10; // expressed in percentage points
+    uint256 public fusionStatsPool = 20;
+    uint256 public cancelRefundBps = 8000; // 80%
+
+    string public constant version = "SpeedH_Minter_AnvilAlchemy-v1.0.0";
+
+    // ---------------------------------------------------------------------
+    // Process bookkeeping
+    // ---------------------------------------------------------------------
+
+    struct FusionPreview {
+        PerformanceStats stats;
+        uint256 maxDurability;
+        uint256 level;
+        bool pure;
+        uint256 imgCategory;
+        uint256 imgNumber;
+    }
+
+    struct FusionProcess {
+        address owner;
+        uint256 fatherId;
+        uint256 motherId;
+        uint256 paidTlos;
+        uint256 entropyNonce;
+        bool finalized;
+        bool hasPreview;
+        FusionPreview preview;
+    }
+
+    uint256 public nextFusionId = 1;
+    mapping(uint256 => FusionProcess) private _fusions;
+
+    // ---------------------------------------------------------------------
+    // Events
+    // ---------------------------------------------------------------------
+
+    event FusionStarted(uint256 indexed fusionId, address indexed owner, uint256 fatherId, uint256 motherId);
+    event FusionRandomized(
+        uint256 indexed fusionId,
+        uint256 level,
+        bool pure,
+        uint256 imgCategory,
+        uint256 imgNumber,
+        bool keepStats
+    );
+    event FusionClaimed(uint256 indexed fusionId, uint256 newHorseshoeId);
+    event FusionCancelled(uint256 indexed fusionId);
+
+    // ---------------------------------------------------------------------
+    // Modifiers
+    // ---------------------------------------------------------------------
+
+    modifier onlyAdmin() {
+        require(msg.sender == admin, "AnvilAlchemy: not admin");
+        _;
+    }
+
+    modifier validFusion(uint256 fusionId) {
+        require(_fusions[fusionId].owner != address(0), "AnvilAlchemy: unknown fusion");
+        _;
+    }
+
+    constructor() {
+        admin = msg.sender;
+    }
+
+    // ---------------------------------------------------------------------
+    // Admin configuration
+    // ---------------------------------------------------------------------
+
+    function setAdmin(address newAdmin) external onlyAdmin {
+        require(newAdmin != address(0), "AnvilAlchemy: invalid admin");
+        admin = newAdmin;
+    }
+
+    function setSpeedStats(address stats) external onlyAdmin {
+        speedStats = ISpeedH_Stats_Fusion(stats);
+    }
+
+    function setHorseshoeNft(address nft) external onlyAdmin {
+        horseshoeNft = ISpeedH_NFT_Horseshoe_MintBurn(nft);
+    }
+
+    function setHayToken(address token) external onlyAdmin {
+        hayToken = IERC20(token);
+    }
+
+    function setFusionTlosCost(uint256 cost) external onlyAdmin {
+        fusionTlosCost = cost;
+    }
+
+    function setRandomizeHayCost(uint256 cost) external onlyAdmin {
+        randomizeHayCost = cost;
+    }
+
+    function setParentError(uint256 errorMargin) external onlyAdmin {
+        require(errorMargin <= 50, "AnvilAlchemy: invalid error");
+        parentError = errorMargin;
+    }
+
+    function setFusionStatsPool(uint256 pool) external onlyAdmin {
+        fusionStatsPool = pool;
+    }
+
+    function setCancelRefund(uint256 refundBps) external onlyAdmin {
+        require(refundBps <= 10_000, "AnvilAlchemy: invalid bps");
+        cancelRefundBps = refundBps;
+    }
+
+    function withdrawTLOS(address payable to, uint256 amount) external onlyAdmin {
+        require(address(this).balance >= amount, "AnvilAlchemy: insufficient balance");
+        to.transfer(amount);
+    }
+
+    function withdrawHAY(address to, uint256 amount) external onlyAdmin {
+        require(hayToken.transfer(to, amount), "AnvilAlchemy: hay transfer failed");
+    }
+
+    // ---------------------------------------------------------------------
+    // User flow
+    // ---------------------------------------------------------------------
+
+    function startFusion(uint256 fatherId, uint256 motherId) external payable returns (uint256 fusionId) {
+        require(address(speedStats) != address(0), "AnvilAlchemy: stats not set");
+        require(address(horseshoeNft) != address(0), "AnvilAlchemy: nft not set");
+        require(msg.value == fusionTlosCost, "AnvilAlchemy: incorrect TLOS");
+        require(fatherId != motherId, "AnvilAlchemy: distinct parents");
+
+        SpeedH_Stats_Horseshoe horseshoeModule = speedStats.horseshoeModule();
+        SpeedH_Stats_Horseshoe.HorseshoeData memory father = horseshoeModule.getHorseshoe(fatherId);
+        SpeedH_Stats_Horseshoe.HorseshoeData memory mother = horseshoeModule.getHorseshoe(motherId);
+
+        require(father.maxDurability > 0 && mother.maxDurability > 0, "AnvilAlchemy: invalid parents");
+        require(!speedStats.isHorseshoeEquipped(fatherId) && !speedStats.isHorseshoeEquipped(motherId), "AnvilAlchemy: equipped");
+        require(
+            horseshoeNft.getApproved(fatherId) == address(this)
+                || horseshoeNft.isApprovedForAll(msg.sender, address(this)),
+            "AnvilAlchemy: father not approved"
+        );
+        require(
+            horseshoeNft.getApproved(motherId) == address(this)
+                || horseshoeNft.isApprovedForAll(msg.sender, address(this)),
+            "AnvilAlchemy: mother not approved"
+        );
+
+        horseshoeNft.transferFrom(msg.sender, address(this), fatherId);
+        horseshoeNft.transferFrom(msg.sender, address(this), motherId);
+
+        fusionId = nextFusionId++;
+        FusionProcess storage process = _fusions[fusionId];
+        process.owner = msg.sender;
+        process.fatherId = fatherId;
+        process.motherId = motherId;
+        process.paidTlos = msg.value;
+
+        emit FusionStarted(fusionId, msg.sender, fatherId, motherId);
+    }
+
+    function randomizeFusion(uint256 fusionId, bool keepStats) external validFusion(fusionId) {
+        FusionProcess storage process = _fusions[fusionId];
+        require(!process.finalized, "AnvilAlchemy: finalized");
+        require(process.owner == msg.sender, "AnvilAlchemy: not owner");
+        require(address(hayToken) != address(0), "AnvilAlchemy: hay not set");
+
+        require(hayToken.transferFrom(msg.sender, address(this), randomizeHayCost), "AnvilAlchemy: hay payment failed");
+
+        SpeedH_Stats_Horseshoe horseshoeModule = speedStats.horseshoeModule();
+        SpeedH_Stats_Horseshoe.HorseshoeData memory father = horseshoeModule.getHorseshoe(process.fatherId);
+        SpeedH_Stats_Horseshoe.HorseshoeData memory mother = horseshoeModule.getHorseshoe(process.motherId);
+
+        FusionPreview memory preview = _buildPreview(process, father, mother, keepStats);
+        process.preview = preview;
+        process.hasPreview = true;
+
+        emit FusionRandomized(fusionId, preview.level, preview.pure, preview.imgCategory, preview.imgNumber, keepStats);
+    }
+
+    function claimFusion(uint256 fusionId) external validFusion(fusionId) {
+        FusionProcess storage process = _fusions[fusionId];
+        require(process.owner == msg.sender, "AnvilAlchemy: not owner");
+        require(!process.finalized, "AnvilAlchemy: already done");
+        require(process.hasPreview, "AnvilAlchemy: no preview");
+
+        uint256 fatherId = process.fatherId;
+        uint256 motherId = process.motherId;
+        FusionPreview memory preview = process.preview;
+        address owner = process.owner;
+
+        process.finalized = true;
+        process.hasPreview = false;
+
+        horseshoeNft.burn(fatherId);
+        horseshoeNft.burn(motherId);
+
+        uint256 newId = horseshoeNft.mint(owner);
+        speedStats.registerForgedHorseshoe(
+            newId,
+            preview.imgCategory,
+            preview.imgNumber,
+            preview.stats,
+            preview.maxDurability,
+            preview.level,
+            preview.pure
+        );
+
+        delete _fusions[fusionId];
+
+        emit FusionClaimed(fusionId, newId);
+    }
+
+    function cancelFusion(uint256 fusionId) external validFusion(fusionId) {
+        FusionProcess storage process = _fusions[fusionId];
+        require(process.owner == msg.sender, "AnvilAlchemy: not owner");
+        require(!process.finalized, "AnvilAlchemy: already done");
+
+        process.finalized = true;
+        process.hasPreview = false;
+
+        address owner = process.owner;
+        uint256 fatherId = process.fatherId;
+        uint256 motherId = process.motherId;
+        uint256 paidTlos = process.paidTlos;
+
+        horseshoeNft.transferFrom(address(this), owner, fatherId);
+        horseshoeNft.transferFrom(address(this), owner, motherId);
+
+        uint256 refund = (paidTlos * cancelRefundBps) / 10_000;
+        if (refund > 0) {
+            payable(owner).transfer(refund);
+        }
+
+        delete _fusions[fusionId];
+
+        emit FusionCancelled(fusionId);
+    }
+
+    function getFusion(uint256 fusionId) external view returns (FusionProcess memory) {
+        return _fusions[fusionId];
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal helpers
+    // ---------------------------------------------------------------------
+
+    function _buildPreview(
+        FusionProcess storage process,
+        SpeedH_Stats_Horseshoe.HorseshoeData memory father,
+        SpeedH_Stats_Horseshoe.HorseshoeData memory mother,
+        bool keepStats
+    ) internal returns (FusionPreview memory) {
+        uint256 fatherPct = _percentageFromRandom(_nextEntropy(process, 0x01));
+        uint256 motherPct = _percentageFromRandom(_nextEntropy(process, 0x02));
+        uint256 ownPct = _percentageFromRandom(_nextEntropy(process, 0x03));
+        uint256 visualEntropy = _nextEntropy(process, 0x04);
+
+        PerformanceStats memory combined;
+        if (keepStats) {
+            combined = _addStats(_scaleStats(father.bonusStats, fatherPct), _scaleStats(mother.bonusStats, motherPct));
+            uint256 ownPoints = (fusionStatsPool * ownPct) / 100;
+            combined = _addStats(combined, _pointsToStats(ownPoints, _nextEntropy(process, 0x05)));
+        } else {
+            uint256 parentPoints = _sumStats(_scaleStats(father.bonusStats, fatherPct))
+                + _sumStats(_scaleStats(mother.bonusStats, motherPct));
+            uint256 totalPoints = parentPoints + ((fusionStatsPool * ownPct) / 100);
+            combined = _distributeAcrossTwo(totalPoints, _nextEntropy(process, 0x06));
+        }
+
+        uint256 maxDurability = father.maxDurability > mother.maxDurability ? father.maxDurability : mother.maxDurability;
+
+        bool pure = father.pure && mother.pure && father.level == mother.level;
+        uint256 level = (father.level > mother.level ? father.level : mother.level) + 1;
+
+        (uint256 imgCategory, uint256 imgNumber) = speedStats.getRandomHorseshoeVisual(visualEntropy);
+
+        return FusionPreview({
+            stats: combined,
+            maxDurability: maxDurability,
+            level: level,
+            pure: pure,
+            imgCategory: imgCategory,
+            imgNumber: imgNumber
+        });
+    }
+
+    function _percentageFromRandom(uint256 randomValue) internal view returns (uint256) {
+        uint256 span = parentError * 2;
+        if (span == 0) {
+            return 50;
+        }
+        return 50 - parentError + (randomValue % span);
+    }
+
+    function _nextEntropy(FusionProcess storage process, uint256 salt) internal returns (uint256) {
+        process.entropyNonce += 1;
+        return uint256(
+            keccak256(abi.encodePacked(block.timestamp, block.prevrandao, process.owner, process.entropyNonce, salt))
+        );
+    }
+
+    function _addStats(PerformanceStats memory a, PerformanceStats memory b) internal pure returns (PerformanceStats memory) {
+        return
+            PerformanceStats({
+                power: a.power + b.power,
+                acceleration: a.acceleration + b.acceleration,
+                stamina: a.stamina + b.stamina,
+                minSpeed: a.minSpeed + b.minSpeed,
+                maxSpeed: a.maxSpeed + b.maxSpeed,
+                luck: a.luck + b.luck,
+                curveBonus: a.curveBonus + b.curveBonus,
+                straightBonus: a.straightBonus + b.straightBonus
+            });
+    }
+
+    function _scaleStats(PerformanceStats memory stats, uint256 pct) internal pure returns (PerformanceStats memory) {
+        return
+            PerformanceStats({
+                power: (stats.power * pct) / 100,
+                acceleration: (stats.acceleration * pct) / 100,
+                stamina: (stats.stamina * pct) / 100,
+                minSpeed: (stats.minSpeed * pct) / 100,
+                maxSpeed: (stats.maxSpeed * pct) / 100,
+                luck: (stats.luck * pct) / 100,
+                curveBonus: (stats.curveBonus * pct) / 100,
+                straightBonus: (stats.straightBonus * pct) / 100
+            });
+    }
+
+    function _pointsToStats(uint256 points, uint256 seed) internal pure returns (PerformanceStats memory) {
+        uint256[8] memory buckets;
+        if (points == 0) {
+            return _zeroStats();
+        }
+        for (uint256 i = 0; i < points; i++) {
+            uint256 idx = uint256(keccak256(abi.encode(seed, i))) % 8;
+            buckets[idx] += 1;
+        }
+        return _fromArray(buckets);
+    }
+
+    function _distributeAcrossTwo(uint256 totalPoints, uint256 seed) internal pure returns (PerformanceStats memory) {
+        if (totalPoints == 0) {
+            return _zeroStats();
+        }
+        uint256 attrA = seed % 8;
+        uint256 attrB = (seed / 8) % 8;
+        if (attrA == attrB) {
+            attrB = (attrB + 1) % 8;
+        }
+        uint256 shareA = totalPoints == 0 ? 0 : (totalPoints * ((seed / 64) % 101)) / 100;
+        if (shareA > totalPoints) {
+            shareA = totalPoints;
+        }
+        uint256 shareB = totalPoints - shareA;
+
+        uint256[8] memory buckets;
+        buckets[attrA] = shareA;
+        buckets[attrB] = shareB;
+        return _fromArray(buckets);
+    }
+
+    function _fromArray(uint256[8] memory buckets) internal pure returns (PerformanceStats memory) {
+        return
+            PerformanceStats({
+                power: buckets[0],
+                acceleration: buckets[1],
+                stamina: buckets[2],
+                minSpeed: buckets[3],
+                maxSpeed: buckets[4],
+                luck: buckets[5],
+                curveBonus: buckets[6],
+                straightBonus: buckets[7]
+            });
+    }
+
+    function _sumStats(PerformanceStats memory stats) internal pure returns (uint256) {
+        return
+            stats.power +
+            stats.acceleration +
+            stats.stamina +
+            stats.minSpeed +
+            stats.maxSpeed +
+            stats.luck +
+            stats.curveBonus +
+            stats.straightBonus;
+    }
+
+    function _zeroStats() internal pure returns (PerformanceStats memory) {
+        return PerformanceStats(0, 0, 0, 0, 0, 0, 0, 0);
+    }
+}

--- a/contracts/SpeedH_Minter_IronRedemption.sol
+++ b/contracts/SpeedH_Minter_IronRedemption.sol
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+import { PerformanceStats } from "./SpeedH_StatsStructs.sol";
+import { SpeedH_Stats_Horseshoe } from "./SpeedH_Stats_Horseshoe.sol";
+
+interface ISpeedH_Stats_Repair {
+    function horseshoeModule() external view returns (SpeedH_Stats_Horseshoe);
+    function isHorseshoeEquipped(uint256 horseshoeId) external view returns (bool);
+    function registerForgedHorseshoe(
+        uint256 horseshoeId,
+        uint256 imgCategory,
+        uint256 imgNumber,
+        PerformanceStats calldata bonusStats,
+        uint256 maxDurability,
+        uint256 level,
+        bool pure
+    ) external;
+}
+
+interface ISpeedH_NFT_Horseshoe_Escrow is IERC721 {
+    function mint(address to) external returns (uint256);
+    function burn(uint256 tokenId) external;
+}
+
+/**
+ * @title SpeedH_Minter_IronRedemption
+ * @notice Handles the staged repair flow for a single horseshoe. Users lock the NFT and pay TLOS, randomize
+ *         the outcome with HAY as many times as desired and finally claim a freshly minted replacement that
+ *         mirrors (with possible degradation) the original statistics. Cancelling returns the NFT and a partial
+ *         refund of the initial fee.
+ */
+contract SpeedH_Minter_IronRedemption {
+    // ---------------------------------------------------------------------
+    // Configuration
+    // ---------------------------------------------------------------------
+
+    address public admin;
+    ISpeedH_Stats_Repair public speedStats;
+    ISpeedH_NFT_Horseshoe_Escrow public horseshoeNft;
+    IERC20 public hayToken;
+
+    uint256 public repairTlosCost = 200 ether;
+    uint256 public randomizeHayCost = 20 ether;
+    uint256 public maxPercentError = 25; // maximum loss percentage
+    uint256 public cancelRefundBps = 8500; // 85%
+
+    string public constant version = "SpeedH_Minter_IronRedemption-v1.0.0";
+
+    struct RepairPreview {
+        PerformanceStats stats;
+        uint256 maxDurability;
+        uint256 level;
+        bool pure;
+        uint256 imgCategory;
+        uint256 imgNumber;
+    }
+
+    struct RepairProcess {
+        address owner;
+        uint256 tokenId;
+        uint256 paidTlos;
+        uint256 entropyNonce;
+        bool finalized;
+        bool hasPreview;
+        RepairPreview baseline;
+        RepairPreview preview;
+    }
+
+    uint256 public nextRepairId = 1;
+    mapping(uint256 => RepairProcess) private _repairs;
+
+    // ---------------------------------------------------------------------
+    // Events
+    // ---------------------------------------------------------------------
+
+    event RepairStarted(uint256 indexed repairId, address indexed owner, uint256 tokenId);
+    event RepairRandomized(uint256 indexed repairId, uint256 level, bool pure, uint256 errorPct);
+    event RepairClaimed(uint256 indexed repairId, uint256 newHorseshoeId);
+    event RepairCancelled(uint256 indexed repairId);
+
+    modifier onlyAdmin() {
+        require(msg.sender == admin, "IronRedemption: not admin");
+        _;
+    }
+
+    modifier validRepair(uint256 repairId) {
+        require(_repairs[repairId].owner != address(0), "IronRedemption: unknown repair");
+        _;
+    }
+
+    constructor() {
+        admin = msg.sender;
+    }
+
+    // ---------------------------------------------------------------------
+    // Admin configuration
+    // ---------------------------------------------------------------------
+
+    function setAdmin(address newAdmin) external onlyAdmin {
+        require(newAdmin != address(0), "IronRedemption: invalid admin");
+        admin = newAdmin;
+    }
+
+    function setSpeedStats(address stats) external onlyAdmin {
+        speedStats = ISpeedH_Stats_Repair(stats);
+    }
+
+    function setHorseshoeNft(address nft) external onlyAdmin {
+        horseshoeNft = ISpeedH_NFT_Horseshoe_Escrow(nft);
+    }
+
+    function setHayToken(address token) external onlyAdmin {
+        hayToken = IERC20(token);
+    }
+
+    function setRepairTlosCost(uint256 cost) external onlyAdmin {
+        repairTlosCost = cost;
+    }
+
+    function setRandomizeHayCost(uint256 cost) external onlyAdmin {
+        randomizeHayCost = cost;
+    }
+
+    function setMaxPercentError(uint256 value) external onlyAdmin {
+        require(value <= 100, "IronRedemption: invalid percent");
+        maxPercentError = value;
+    }
+
+    function setCancelRefund(uint256 refundBps) external onlyAdmin {
+        require(refundBps <= 10_000, "IronRedemption: invalid bps");
+        cancelRefundBps = refundBps;
+    }
+
+    function withdrawTLOS(address payable to, uint256 amount) external onlyAdmin {
+        require(address(this).balance >= amount, "IronRedemption: insufficient balance");
+        to.transfer(amount);
+    }
+
+    function withdrawHAY(address to, uint256 amount) external onlyAdmin {
+        require(hayToken.transfer(to, amount), "IronRedemption: hay transfer failed");
+    }
+
+    // ---------------------------------------------------------------------
+    // User flow
+    // ---------------------------------------------------------------------
+
+    function startRepair(uint256 tokenId) external payable returns (uint256 repairId) {
+        require(address(speedStats) != address(0), "IronRedemption: stats not set");
+        require(address(horseshoeNft) != address(0), "IronRedemption: nft not set");
+        require(msg.value == repairTlosCost, "IronRedemption: incorrect TLOS");
+
+        SpeedH_Stats_Horseshoe horseshoeModule = speedStats.horseshoeModule();
+        SpeedH_Stats_Horseshoe.HorseshoeData memory data = horseshoeModule.getHorseshoe(tokenId);
+        require(data.maxDurability > 0, "IronRedemption: unknown horseshoe");
+        require(!speedStats.isHorseshoeEquipped(tokenId), "IronRedemption: equipped");
+        require(
+            horseshoeNft.getApproved(tokenId) == address(this)
+                || horseshoeNft.isApprovedForAll(msg.sender, address(this)),
+            "IronRedemption: approval missing"
+        );
+
+        horseshoeNft.transferFrom(msg.sender, address(this), tokenId);
+
+        repairId = nextRepairId++;
+        RepairProcess storage process = _repairs[repairId];
+        process.owner = msg.sender;
+        process.tokenId = tokenId;
+        process.paidTlos = msg.value;
+        RepairPreview memory snapshot = RepairPreview({
+            stats: data.bonusStats,
+            maxDurability: data.maxDurability,
+            level: data.level,
+            pure: data.pure,
+            imgCategory: data.imgCategory,
+            imgNumber: data.imgNumber
+        });
+        process.baseline = snapshot;
+        process.preview = snapshot;
+
+        emit RepairStarted(repairId, msg.sender, tokenId);
+    }
+
+    function randomizeRepair(uint256 repairId) external validRepair(repairId) {
+        RepairProcess storage process = _repairs[repairId];
+        require(!process.finalized, "IronRedemption: finalized");
+        require(process.owner == msg.sender, "IronRedemption: not owner");
+        require(address(hayToken) != address(0), "IronRedemption: hay not set");
+
+        require(hayToken.transferFrom(msg.sender, address(this), randomizeHayCost), "IronRedemption: hay payment failed");
+
+        uint256 errorPct = _nextEntropy(process) % (maxPercentError + 1);
+        RepairPreview memory base = process.baseline;
+
+        PerformanceStats memory degraded = _scaleStats(base.stats, 100 - errorPct);
+        bool isPure = base.pure && errorPct == 0;
+
+        RepairPreview memory preview = RepairPreview({
+            stats: degraded,
+            maxDurability: base.maxDurability,
+            level: base.level,
+            pure: isPure,
+            imgCategory: base.imgCategory,
+            imgNumber: base.imgNumber
+        });
+
+        process.preview = preview;
+        process.hasPreview = true;
+
+        emit RepairRandomized(repairId, preview.level, preview.pure, errorPct);
+    }
+
+    function claimRepair(uint256 repairId) external validRepair(repairId) {
+        RepairProcess storage process = _repairs[repairId];
+        require(process.owner == msg.sender, "IronRedemption: not owner");
+        require(!process.finalized, "IronRedemption: already done");
+        require(process.hasPreview, "IronRedemption: no preview");
+
+        uint256 tokenId = process.tokenId;
+        RepairPreview memory preview = process.preview;
+        address owner = process.owner;
+
+        process.finalized = true;
+        process.hasPreview = false;
+
+        horseshoeNft.burn(tokenId);
+
+        uint256 newId = horseshoeNft.mint(owner);
+        speedStats.registerForgedHorseshoe(
+            newId,
+            preview.imgCategory,
+            preview.imgNumber,
+            preview.stats,
+            preview.maxDurability,
+            preview.level,
+            preview.pure
+        );
+
+        delete _repairs[repairId];
+
+        emit RepairClaimed(repairId, newId);
+    }
+
+    function cancelRepair(uint256 repairId) external validRepair(repairId) {
+        RepairProcess storage process = _repairs[repairId];
+        require(process.owner == msg.sender, "IronRedemption: not owner");
+        require(!process.finalized, "IronRedemption: already done");
+
+        process.finalized = true;
+        process.hasPreview = false;
+
+        address owner = process.owner;
+        uint256 tokenId = process.tokenId;
+        uint256 paidTlos = process.paidTlos;
+
+        horseshoeNft.transferFrom(address(this), owner, tokenId);
+
+        uint256 refund = (paidTlos * cancelRefundBps) / 10_000;
+        if (refund > 0) {
+            payable(owner).transfer(refund);
+        }
+
+        delete _repairs[repairId];
+
+        emit RepairCancelled(repairId);
+    }
+
+    function getRepair(uint256 repairId) external view returns (RepairProcess memory) {
+        return _repairs[repairId];
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal helpers
+    // ---------------------------------------------------------------------
+
+    function _nextEntropy(RepairProcess storage process) internal returns (uint256) {
+        process.entropyNonce += 1;
+        return uint256(keccak256(abi.encodePacked(block.timestamp, block.prevrandao, process.owner, process.entropyNonce)));
+    }
+
+    function _scaleStats(PerformanceStats memory stats, uint256 pct) internal pure returns (PerformanceStats memory) {
+        return
+            PerformanceStats({
+                power: (stats.power * pct) / 100,
+                acceleration: (stats.acceleration * pct) / 100,
+                stamina: (stats.stamina * pct) / 100,
+                minSpeed: (stats.minSpeed * pct) / 100,
+                maxSpeed: (stats.maxSpeed * pct) / 100,
+                luck: (stats.luck * pct) / 100,
+                curveBonus: (stats.curveBonus * pct) / 100,
+                straightBonus: (stats.straightBonus * pct) / 100
+            });
+    }
+}

--- a/contracts/SpeedH_Stats_Horseshoe.sol
+++ b/contracts/SpeedH_Stats_Horseshoe.sol
@@ -14,7 +14,7 @@ contract SpeedH_Stats_Horseshoe {
 
     address public owner;
     address public speedStats;
-    string public version = "SpeedH_Stats_Horseshoe-v1.0.0";
+    string public version = "SpeedH_Stats_Horseshoe-v1.1.0";
 
     modifier onlyOwner() {
         require(msg.sender == owner, "SpeedH_Stats_Horseshoe: not owner");
@@ -48,6 +48,8 @@ contract SpeedH_Stats_Horseshoe {
         PerformanceStats bonusStats;
         uint256 maxDurability;
         uint256 durabilityUsed;
+        uint256 level;
+        bool pure;
     }
 
     mapping(uint256 => HorseshoeData) private horseshoes;
@@ -88,7 +90,9 @@ contract SpeedH_Stats_Horseshoe {
         uint256 imgCategory,
         uint256 imgNumber,
         PerformanceStats calldata bonusStats,
-        uint256 maxDurability
+        uint256 maxDurability,
+        uint256 level,
+        bool pure
     ) external onlySpeedStats {
         HorseshoeData storage data = horseshoes[horseshoeId];
         require(data.maxDurability == 0, "SpeedH_Stats_Horseshoe: horseshoe exists");
@@ -103,6 +107,8 @@ contract SpeedH_Stats_Horseshoe {
         data.bonusStats = bonusStats;
         data.maxDurability = maxDurability;
         data.durabilityUsed = maxDurability; // as per your current semantics
+        data.level = level;
+        data.pure = pure;
     }
 
     function restore(uint256 horseshoeId) external onlySpeedStats {

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,7 +2,7 @@
 - SpeedH_HayTokenOFT.sol
 - SpeedH_NFT_Horse.sol
 - SpeedH_Stats_Horse.sol
-- SpeedH_FoalForge.sol
+- SpeedH_Minter_FoalForge.sol
 
 
 


### PR DESCRIPTION
## Summary
- rename the FoalForge minter and update starter horseshoe minting to emit level and purity metadata
- extend horseshoe stats/NFT contracts with level & purity tracking plus multi-minter and burn support
- add dedicated fusion and repair minter workflows for combining and restoring horseshoes

## Testing
- not run (contracts only)


------
https://chatgpt.com/codex/tasks/task_e_68def0234148832096d5bf02a84996e7