### PR TITLE
Align FoalForge horseshoe registration with other minters

### DIFF
--- a/contracts/SpeedH_Minter_FoalForge.sol
+++ b/contracts/SpeedH_Minter_FoalForge.sol
@@ -7,6 +7,15 @@ interface ISpeedH_Stats_Horse {
     function createHorse(uint256 horseId, uint256 imgCategory, uint256 imgNumber, PerformanceStats calldata baseStats) external;
     function getRandomVisual(uint256 entropy) external view returns (uint256 imgCategory, uint256 imgNumber);
     function getRandomHorseshoeVisual(uint256 entropy) external view returns (uint256 imgCategory, uint256 imgNumber);
+    function registerForgedHorseshoe(
+        uint256 horseshoeId,
+        uint256 imgCategory,
+        uint256 imgNumber,
+        PerformanceStats calldata bonusStats,
+        uint256 maxDurability,
+        uint256 level,
+        bool pure
+    ) external;
     function createStarterHorseshoe(
         uint256 horseId,
         uint256 horseshoeId,
@@ -129,6 +138,15 @@ contract SpeedH_Minter_FoalForge {
         for (uint256 i = 0; i < HORSESHOES_PER_HORSE; i++) {
             PendingHorseshoe memory shoe = build.horseshoes[i];
             uint256 horseshoeId = horseshoes.mint(msg.sender);
+            horseStats.registerForgedHorseshoe(
+                horseshoeId,
+                shoe.imgCategory,
+                shoe.imgNumber,
+                shoe.bonusStats,
+                STARTER_HORSESHOE_DURABILITY,
+                0,
+                true
+            );
             horseStats.createStarterHorseshoe(
                 horseId,
                 horseshoeId,
@@ -136,7 +154,7 @@ contract SpeedH_Minter_FoalForge {
                 shoe.imgNumber,
                 shoe.bonusStats,
                 STARTER_HORSESHOE_DURABILITY,
-                1,
+                0,
                 true
             );
         }

--- a/contracts/SpeedH_Stats.sol
+++ b/contracts/SpeedH_Stats.sol
@@ -246,8 +246,18 @@ contract SpeedH_Stats {
         require(address(horseshoeModule) != address(0), "SpeedH_Stats: horseshoe module not set");
         require(address(horseModule) != address(0), "SpeedH_Stats: horse module not set");
         require(speedHorsesToken != address(0) && horseshoesToken != address(0), "SpeedH_Stats: tokens not set");
-        horseshoeModule.createHorseshoe(horseshoeId, imgCategory, imgNumber, bonusStats, maxDurability, level, pure);
-        emit HorseshoeCreated(horseshoeId, imgCategory, imgNumber, bonusStats, maxDurability, level, pure);
+
+        bool exists = true;
+        try horseshoeModule.getHorseshoe(horseshoeId) returns (SpeedH_Stats_Horseshoe.HorseshoeData memory /*existing*/) {
+            // Horseshoe already registered, nothing else to do before equipping.
+        } catch {
+            exists = false;
+        }
+
+        if (!exists) {
+            horseshoeModule.createHorseshoe(horseshoeId, imgCategory, imgNumber, bonusStats, maxDurability, level, pure);
+            emit HorseshoeCreated(horseshoeId, imgCategory, imgNumber, bonusStats, maxDurability, level, pure);
+        }
 
         // Will revert if the horse does not exist
         horseModule.getHorse(horseId);


### PR DESCRIPTION
## Summary
- call `registerForgedHorseshoe` from `SpeedH_Minter_FoalForge` after minting starter horseshoes and set their base level to 0
- let `SpeedH_Stats.createStarterHorseshoe` reuse already-registered horseshoes to avoid double creation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68defe2cc3008320aa5c98728ed9ea2c