### PR TITLE
Rename stats registration functions and restore horseshoe existence flag

### DIFF
--- a/contracts/SpeedH_Minter_AnvilAlchemy.sol
+++ b/contracts/SpeedH_Minter_AnvilAlchemy.sol
@@ -11,7 +11,7 @@ interface ISpeedH_Stats_Fusion {
     function horseshoeModule() external view returns (SpeedH_Stats_Horseshoe);
     function isHorseshoeEquipped(uint256 horseshoeId) external view returns (bool);
     function getRandomHorseshoeVisual(uint256 entropy) external view returns (uint256, uint256);
-    function registerForgedHorseshoe(
+    function registerHorseshoeStats(
         uint256 horseshoeId,
         uint256 imgCategory,
         uint256 imgNumber,
@@ -242,7 +242,7 @@ contract SpeedH_Minter_AnvilAlchemy {
         horseshoeNft.burn(motherId);
 
         uint256 newId = horseshoeNft.mint(owner);
-        speedStats.registerForgedHorseshoe(
+        speedStats.registerHorseshoeStats(
             newId,
             preview.imgCategory,
             preview.imgNumber,

--- a/contracts/SpeedH_Minter_FoalForge.sol
+++ b/contracts/SpeedH_Minter_FoalForge.sol
@@ -4,10 +4,15 @@ pragma solidity ^0.8.20;
 import { PerformanceStats } from "./SpeedH_StatsStructs.sol";
 
 interface ISpeedH_Stats_Horse {
-    function createHorse(uint256 horseId, uint256 imgCategory, uint256 imgNumber, PerformanceStats calldata baseStats) external;
+    function createHorseStats(
+        uint256 horseId,
+        uint256 imgCategory,
+        uint256 imgNumber,
+        PerformanceStats calldata baseStats
+    ) external;
     function getRandomVisual(uint256 entropy) external view returns (uint256 imgCategory, uint256 imgNumber);
     function getRandomHorseshoeVisual(uint256 entropy) external view returns (uint256 imgCategory, uint256 imgNumber);
-    function createStarterHorseshoe(
+    function registerStarterHorseshoeStats(
         uint256 horseId,
         uint256 horseshoeId,
         uint256 imgCategory,
@@ -15,7 +20,7 @@ interface ISpeedH_Stats_Horse {
         PerformanceStats calldata bonusStats,
         uint256 maxDurability,
         uint256 level,
-        bool pure
+        bool isPure
     ) external;
 }
 
@@ -124,12 +129,12 @@ contract SpeedH_Minter_FoalForge {
 
         uint256 horseId = nextHorseId++;
         speedHorses.mint(msg.sender, horseId);
-        horseStats.createHorse(horseId, build.imgCategory, build.imgNumber, build.baseStats);
+        horseStats.createHorseStats(horseId, build.imgCategory, build.imgNumber, build.baseStats);
 
         for (uint256 i = 0; i < HORSESHOES_PER_HORSE; i++) {
             PendingHorseshoe memory shoe = build.horseshoes[i];
             uint256 horseshoeId = horseshoes.mint(msg.sender);
-            horseStats.createStarterHorseshoe(
+            horseStats.registerStarterHorseshoeStats(
                 horseId,
                 horseshoeId,
                 shoe.imgCategory,

--- a/contracts/SpeedH_Minter_IronRedemption.sol
+++ b/contracts/SpeedH_Minter_IronRedemption.sol
@@ -10,14 +10,14 @@ import { SpeedH_Stats_Horseshoe } from "./SpeedH_Stats_Horseshoe.sol";
 interface ISpeedH_Stats_Repair {
     function horseshoeModule() external view returns (SpeedH_Stats_Horseshoe);
     function isHorseshoeEquipped(uint256 horseshoeId) external view returns (bool);
-    function registerForgedHorseshoe(
+    function registerHorseshoeStats(
         uint256 horseshoeId,
         uint256 imgCategory,
         uint256 imgNumber,
         PerformanceStats calldata bonusStats,
         uint256 maxDurability,
         uint256 level,
-        boolean isPure
+        bool isPure
     ) external;
 }
 
@@ -54,7 +54,7 @@ contract SpeedH_Minter_IronRedemption {
         PerformanceStats stats;
         uint256 maxDurability;
         uint256 level;
-        boolean isPure;
+        bool isPure;
         uint256 imgCategory;
         uint256 imgNumber;
     }
@@ -78,7 +78,7 @@ contract SpeedH_Minter_IronRedemption {
     // ---------------------------------------------------------------------
 
     event RepairStarted(uint256 indexed repairId, address indexed owner, uint256 tokenId);
-    event RepairRandomized(uint256 indexed repairId, uint256 level, bool pure, uint256 errorPct);
+    event RepairRandomized(uint256 indexed repairId, uint256 level, bool isPure, uint256 errorPct);
     event RepairClaimed(uint256 indexed repairId, uint256 newHorseshoeId);
     event RepairCancelled(uint256 indexed repairId);
 
@@ -229,7 +229,7 @@ contract SpeedH_Minter_IronRedemption {
         horseshoeNft.burn(tokenId);
 
         uint256 newId = horseshoeNft.mint(owner);
-        speedStats.registerForgedHorseshoe(
+        speedStats.registerHorseshoeStats(
             newId,
             preview.imgCategory,
             preview.imgNumber,

--- a/contracts/SpeedH_Stats.sol
+++ b/contracts/SpeedH_Stats.sol
@@ -142,13 +142,13 @@ contract SpeedH_Stats {
     uint256 public constant LEVEL_STEP = 50;
     uint256 public constant FEEDING_COST_PER_POINT = 1 ether;
 
-    function createHorse(
+    function createHorseStats(
         uint256 horseId,
         uint256 imgCategory,
         uint256 imgNumber,
         PerformanceStats calldata baseStats
     ) external onlyHorseMinter {
-        horseModule.createHorse(horseId, imgCategory, imgNumber, baseStats);
+        horseModule.createHorseStats(horseId, imgCategory, imgNumber, baseStats);
         emit HorseCreated(horseId, imgCategory, imgNumber, baseStats);
     }
 
@@ -183,7 +183,7 @@ contract SpeedH_Stats {
     // ---------------------------------------------------------------------
 
     /// @dev maxAdjustments removed to match SpeedH_Stats_Horseshoe; event updated accordingly.
-    event HorseshoeCreated(
+    event HorseshoeStats(
         uint256 indexed horseshoeId,
         uint256 imgCategory,
         uint256 imgNumber,
@@ -214,12 +214,20 @@ contract SpeedH_Stats {
         uint256 level,
         bool isPure
     ) external onlyHorseMinter {
-        horseshoeModule.createHorseshoe(horseshoeId, imgCategory, imgNumber, bonusStats, maxDurability, level, isPure);
-        emit HorseshoeCreated(horseshoeId, imgCategory, imgNumber, bonusStats, maxDurability, level, isPure);
+        horseshoeModule.createHorseshoeStats(
+            horseshoeId,
+            imgCategory,
+            imgNumber,
+            bonusStats,
+            maxDurability,
+            level,
+            isPure
+        );
+        emit HorseshoeStats(horseshoeId, imgCategory, imgNumber, bonusStats, maxDurability, level, isPure);
     }
 
     /// @notice Hook used by the minter to materialize the starter horseshoes and equip them immediately.
-    function createStarterHorseshoe(
+    function registerStarterHorseshoeStats(
         uint256 horseId,
         uint256 horseshoeId,
         uint256 imgCategory,
@@ -233,7 +241,7 @@ contract SpeedH_Stats {
         require(address(horseModule) != address(0), "SpeedH_Stats: horse module not set");
         require(speedHorsesToken != address(0) && horseshoesToken != address(0), "SpeedH_Stats: tokens not set");
         // Create the horseshoe record
-        registerForgedHorseshoe(
+        registerHorseshoeStats(
             horseshoeId,
             imgCategory,
             imgNumber,

--- a/contracts/SpeedH_Stats_Horse.sol
+++ b/contracts/SpeedH_Stats_Horse.sol
@@ -85,7 +85,7 @@ contract SpeedH_Stats_Horse {
     // Horse mutations (only controller)
     // ---------------------------------------------------------------------
 
-    function createHorse(
+    function createHorseStats(
         uint256 horseId,
         uint256 imgCategory,
         uint256 imgNumber,

--- a/contracts/SpeedH_Stats_Horseshoe.sol
+++ b/contracts/SpeedH_Stats_Horseshoe.sol
@@ -49,7 +49,8 @@ contract SpeedH_Stats_Horseshoe {
         uint256 maxDurability;
         uint256 durabilityUsed;
         uint256 level;
-        bool pure;
+        bool isPure;
+        bool exists;
     }
 
     mapping(uint256 => HorseshoeData) private horseshoes;
@@ -85,17 +86,17 @@ contract SpeedH_Stats_Horseshoe {
     // Lifecycle
     // ---------------------------------------------------------------------
 
-    function createHorseshoe(
+    function createHorseshoeStats(
         uint256 horseshoeId,
         uint256 imgCategory,
         uint256 imgNumber,
         PerformanceStats calldata bonusStats,
         uint256 maxDurability,
         uint256 level,
-        bool pure
+        bool isPure
     ) external onlySpeedStats {
         HorseshoeData storage data = horseshoes[horseshoeId];
-        require(data.maxDurability == 0, "SpeedH_Stats_Horseshoe: horseshoe exists");
+        require(!data.exists, "SpeedH_Stats_Horseshoe: horseshoe exists");
         require(maxDurability > 0, "SpeedH_Stats_Horseshoe: invalid durability");
 
         SpeedH_VisualsLib.ImgCategoryData storage cat = shoeVisuals.imgCategories[imgCategory];
@@ -108,25 +109,26 @@ contract SpeedH_Stats_Horseshoe {
         data.maxDurability = maxDurability;
         data.durabilityUsed = maxDurability; // as per your current semantics
         data.level = level;
-        data.pure = pure;
+        data.isPure = isPure;
+        data.exists = true;
     }
 
     function restore(uint256 horseshoeId) external onlySpeedStats {
         HorseshoeData storage data = horseshoes[horseshoeId];
-        require(data.maxDurability > 0, "SpeedH_Stats_Horseshoe: unknown horseshoe");
+        require(data.exists, "SpeedH_Stats_Horseshoe: unknown horseshoe");
         data.durabilityUsed = data.maxDurability;
     }
 
     function consume(uint256 horseshoeId, uint256 less) external onlySpeedStats {
         HorseshoeData storage data = horseshoes[horseshoeId];
-        require(data.maxDurability > 0, "SpeedH_Stats_Horseshoe: unknown horseshoe");
+        require(data.exists, "SpeedH_Stats_Horseshoe: unknown horseshoe");
         require(less > data.durabilityUsed, "SpeedH_Stats_Horseshoe: insufficient durability");
         data.durabilityUsed = data.durabilityUsed - less;
     }
 
     function getHorseshoe(uint256 horseshoeId) external view returns (HorseshoeData memory) {
         HorseshoeData memory data = horseshoes[horseshoeId];
-        require(data.maxDurability > 0, "SpeedH_Stats_Horseshoe: unknown horseshoe");
+        require(data.exists, "SpeedH_Stats_Horseshoe: unknown horseshoe");
         return data;
     }
 }


### PR DESCRIPTION
## Summary
- rename horse and horseshoe registration entrypoints/events to their `*Stats` variants
- restore the horseshoe existence flag and update related modules to use `isPure`

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfe9c72a2883209a1855bfdfab9237