### PR TITLE
Add confirmation dialog before buying extra forge points

### DIFF
--- a/public/assets/locals/en.json
+++ b/public/assets/locals/en.json
@@ -34,6 +34,12 @@
                 "STATS-UNLOCKED": "Base stats can be shuffled",
                 "HORSESHOES": "Horseshoes",
                 "BUY-MORE": "Buy more",
+                "BUY-MORE-DIALOG": {
+                    "TITLE": "Buy Extra Points",
+                    "MESSAGE": "Spend 100 TLOS to add 10 extra stat points to your foal. Do you want to continue?",
+                    "CONFIRM": "Buy points",
+                    "CANCEL": "Cancel"
+                },
                 "SHUFFLE": "Shuffle",
                 "FORGE": "Forge",
                 "CLAIM": {

--- a/public/assets/locals/es.json
+++ b/public/assets/locals/es.json
@@ -34,6 +34,12 @@
                 "STATS-UNLOCKED": "Las estadísticas base pueden mezclarse",
                 "HORSESHOES": "Herraduras",
                 "BUY-MORE": "Comprar más",
+                "BUY-MORE-DIALOG": {
+                    "TITLE": "Comprar puntos extra",
+                    "MESSAGE": "Paga 100 TLOS para añadir 10 puntos adicionales a las estadísticas de tu potro. ¿Deseas continuar?",
+                    "CONFIRM": "Comprar puntos",
+                    "CANCEL": "Cancelar"
+                },
                 "SHUFFLE": "Mezclar",
                 "FORGE": "Forjar",
                 "CLAIM": {

--- a/src/app/pages/forge/forge.component.html
+++ b/src/app/pages/forge/forge.component.html
@@ -165,4 +165,13 @@
         (cancel)="onCancelClaim()"
         (confirm)="onConfirmClaim()"
     ></app-confirm-dialog>
+    <app-confirm-dialog
+        [(nodel)]="buyExtraPointsConfirmVisible"
+        [title]="'PAGES.HORSES.FORGE.BUY-MORE-DIALOG.TITLE' | translate"
+        [message]="'PAGES.HORSES.FORGE.BUY-MORE-DIALOG.MESSAGE' | translate"
+        [cancelText]="'PAGES.HORSES.FORGE.BUY-MORE-DIALOG.CANCEL' | translate"
+        [confirmText]="'PAGES.HORSES.FORGE.BUY-MORE-DIALOG.CONFIRM' | translate"
+        (cancel)="onCancelBuyExtraPoints()"
+        (confirm)="onConfirmBuyExtraPoints()"
+    ></app-confirm-dialog>
 </section>

--- a/src/app/pages/forge/forge.component.ts
+++ b/src/app/pages/forge/forge.component.ts
@@ -42,6 +42,7 @@ export class ForgePage implements OnInit, OnDestroy {
     lock_picture = false;
     summonConfirmVisible = false;
     claimConfirmVisible = false;
+    buyExtraPointsConfirmVisible = false;
     viewState: 'default' | 'current' | 'success' = 'default';
     public currentFoal: SpeedHorsesFoal = null;
     private successFoal: SpeedHorsesFoal = null;
@@ -134,6 +135,15 @@ export class ForgePage implements OnInit, OnDestroy {
     }
 
     onBuyExtraPoints(): void {
+        this.buyExtraPointsConfirmVisible = true;
+    }
+
+    onCancelBuyExtraPoints(): void {
+        this.buyExtraPointsConfirmVisible = false;
+    }
+
+    onConfirmBuyExtraPoints(): void {
+        this.buyExtraPointsConfirmVisible = false;
         this.withAuth('onBuyExtraPoints', {}, (service, auth, context) => {
             service.buyExtraPoints(auth, context).subscribe({
                 next: foal => console.log('[ForgePage] buyExtraPoints result', foal),


### PR DESCRIPTION
## Summary
- prompt the user with a confirmation dialog before purchasing extra forge points
- trigger the existing buyExtraPoints logic only after the player confirms the purchase
- localize the new confirmation dialog copy in both English and Spanish

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68f59cc0900083209486038cbe095623